### PR TITLE
Fix ignored card_type property in CardTraitDataPipeline

### DIFF
--- a/TrainworksReloaded.Base/Relic/RelicDataPipeline.cs
+++ b/TrainworksReloaded.Base/Relic/RelicDataPipeline.cs
@@ -88,7 +88,7 @@ namespace TrainworksReloaded.Base.Relic
                 return null;
             data.name = name;
             var guid = _guidProvider.GetGuidDeterministic(name);
-            AccessTools.Field(typeof(RelicData), "id").SetValue(data, guid);
+            AccessTools.Field(typeof(RelicData), "id").SetValue(data, guid.ToString());
 
             // Create localization keys
             var nameKey = $"RelicData_titleKey-{name}";

--- a/TrainworksReloaded.Base/Relic/RelicEffectDataFinalizer.cs
+++ b/TrainworksReloaded.Base/Relic/RelicEffectDataFinalizer.cs
@@ -226,7 +226,7 @@ namespace TrainworksReloaded.Base.Relic
 
             // Handle card upgrade data
             var cardUpgradeDataId = configuration.GetSection("param_card_upgrade_data").ParseString();
-            if (cardUpgradeDataId != null && upgradeRegister.TryLookupId(cardUpgradeDataId.ToId(key, TemplateConstants.Upgrade), out var cardUpgradeData, out var _))
+            if (cardUpgradeDataId != null && upgradeRegister.TryLookupName(cardUpgradeDataId.ToId(key, TemplateConstants.Upgrade), out var cardUpgradeData, out var _))
             {
                 AccessTools.Field(typeof(RelicEffectData), "paramCardUpgradeData").SetValue(data, cardUpgradeData);
             }

--- a/TrainworksReloaded.Base/Trait/CardTraitDataPipeline.cs
+++ b/TrainworksReloaded.Base/Trait/CardTraitDataPipeline.cs
@@ -97,7 +97,7 @@ namespace TrainworksReloaded.Base.Trait
                 .Field(typeof(CardTraitData), "paramCardType")
                 .SetValue(
                     data,
-                    configuration.GetSection("track_type").ParseCardTypeTarget() ?? paramCardType
+                    configuration.GetSection("card_type").ParseCardTypeTarget() ?? paramCardType
                 );
 
             var paramEntryDuration = CardStatistics.EntryDuration.ThisTurn;


### PR DESCRIPTION
## Summary
Bug fixes

## Changes
For paramCardType CardTraitDataPipeline ignored card_type.
RelicEffectDataPipeline passed a GUID when setting the id
RelicEffectDataFinalizer attempted to search card upgrades by their internal id and not the name.