### PR TITLE
Various bugfixes.

### DIFF
--- a/TrainworksReloaded.Base/Card/CardDataPipeline.cs
+++ b/TrainworksReloaded.Base/Card/CardDataPipeline.cs
@@ -134,9 +134,9 @@ namespace TrainworksReloaded.Base.Card
             //handle tooltips
             int tooltip_count = 0;
             var tooltips = checkOverride
-                ? []
-                : (List<String>)
-                    AccessTools.Field(typeof(CardData), "cardLoreTooltipKeys").GetValue(data);
+                ? (List<String>)
+                    AccessTools.Field(typeof(CardData), "cardLoreTooltipKeys").GetValue(data)
+                : [];
             foreach (var tooltip in configuration.GetSection("lore_tooltips").GetChildren())
             {
                 var localizationTooltipTerm = tooltip.ParseLocalizationTerm();
@@ -150,11 +150,13 @@ namespace TrainworksReloaded.Base.Card
                     else
                     {
                         localizationTooltipTerm.Key = tooltipKey;
+                        tooltips.Add(localizationTooltipTerm.Key);
                     }
                     termRegister.Register(tooltipKey, localizationTooltipTerm);
                     tooltip_count++;
                 }
             }
+            AccessTools.Field(typeof(CardData), "cardLoreTooltipKeys").SetValue(data, tooltips);
 
             //handle one-to-one values
             var defaultCost = checkOverride

--- a/TrainworksReloaded.Base/Card/CardDataPipeline.cs
+++ b/TrainworksReloaded.Base/Card/CardDataPipeline.cs
@@ -209,8 +209,7 @@ namespace TrainworksReloaded.Base.Card
                 .SetValue(data, configuration.GetSection("ability").ParseBool() ?? defaultAbility);
 
             var defaultTargetsRoom =
-                checkOverride
-                && (bool)AccessTools.Field(typeof(CardData), "targetsRoom").GetValue(data);
+                checkOverride ? (bool)AccessTools.Field(typeof(CardData), "targetsRoom").GetValue(data) : true;
             AccessTools
                 .Field(typeof(CardData), "targetsRoom")
                 .SetValue(

--- a/TrainworksReloaded.Base/Character/CharacterDataPipeline.cs
+++ b/TrainworksReloaded.Base/Character/CharacterDataPipeline.cs
@@ -383,6 +383,33 @@ namespace TrainworksReloaded.Base.Character
                     subtypes.Add(str);
             }
 
+            //handle tooltips
+            int tooltip_count = 0;
+            var tooltips = checkOverride
+                ? (List<String>)
+                    AccessTools.Field(typeof(CharacterData), "characterLoreTooltipKeys").GetValue(data)
+                : [];
+            foreach (var tooltip in configuration.GetSection("character_lore_tooltips").GetChildren())
+            {
+                var localizationTooltipTerm = tooltip.ParseLocalizationTerm();
+                if (localizationTooltipTerm != null)
+                {
+                    string tooltipKey = $"CharacterData_tooltipKey{tooltip_count}-{name}";
+                    if (checkOverride && tooltips.Contains(localizationTooltipTerm.Key))
+                    {
+                        tooltipKey = localizationTooltipTerm.Key;
+                    }
+                    else
+                    {
+                        localizationTooltipTerm.Key = tooltipKey;
+                        tooltips.Add(localizationTooltipTerm.Key);
+                    }
+                    termRegister.Register(tooltipKey, localizationTooltipTerm);
+                    tooltip_count++;
+                }
+            }
+            AccessTools.Field(typeof(CharacterData), "characterLoreTooltipKeys").SetValue(data, tooltips);
+
             //endless baseline stats
             var endlessBaselineStats = checkOverride
                 ? (EndlessBaselineStats)

--- a/TrainworksReloaded.Base/Effect/CardEffectDataPipeline.cs
+++ b/TrainworksReloaded.Base/Effect/CardEffectDataPipeline.cs
@@ -86,7 +86,7 @@ namespace TrainworksReloaded.Base.Effect
                 .SetValue(data, fullyQualifiedName);
 
             //strings
-            var targetCharacterSubtype = "";
+            var targetCharacterSubtype = "SubtypesData_None";
             AccessTools
                 .Field(typeof(CardEffectData), "targetCharacterSubtype")
                 .SetValue(
@@ -100,7 +100,7 @@ namespace TrainworksReloaded.Base.Effect
                 .Field(typeof(CardEffectData), "paramStr")
                 .SetValue(data, configuration.GetSection("param_str").ParseString() ?? paramStr);
 
-            var paramSubtype = "";
+            var paramSubtype = "SubtypesData_None";
             AccessTools
                 .Field(typeof(CardEffectData), "paramSubtype")
                 .SetValue(
@@ -279,7 +279,7 @@ namespace TrainworksReloaded.Base.Effect
                 );
 
             //floats
-            var paramMultiplier = 0.0f;
+            var paramMultiplier = 1.0f;
             AccessTools
                 .Field(typeof(CardEffectData), "paramMultiplier")
                 .SetValue(

--- a/TrainworksReloaded.Base/Extensions/ParseEnumExtensions.cs
+++ b/TrainworksReloaded.Base/Extensions/ParseEnumExtensions.cs
@@ -156,6 +156,21 @@ namespace TrainworksReloaded.Base.Extensions
             return new Color(r ?? 0.0f, g ?? 0.0f, b ?? 0.0f, a ?? 1.0f);
         }
 
+        public static string? ParseLocalization(this IConfigurationSection section)
+        {
+            var str = section.Value;
+            if (string.IsNullOrEmpty(str))
+            {
+                return null;
+            }
+            // Quote string if it contains quotes otherwise it will break when sending to I2.Loc
+            if (str.Contains(','))
+            {
+                str = string.Format("\"{0}\"", str);
+            }
+            return str;
+        }
+
         public static LocalizationTerm? ParseLocalizationTerm(this IConfigurationSection section)
         {
             var key = section.GetSection("id").Value;
@@ -163,16 +178,16 @@ namespace TrainworksReloaded.Base.Extensions
             var description = section.GetSection("description").Value;
             var group = section.GetSection("group").Value;
             var speaker_descriptions = section.GetSection("speaker_descriptions").Value;
-            var english = section.GetSection("english").Value;
-            var french = section.GetSection("french").Value;
-            var german = section.GetSection("german").Value;
-            var russian = section.GetSection("russian").Value;
-            var portuguese = section.GetSection("portuguese").Value;
-            var chinese = section.GetSection("chinese").Value;
-            var spanish = section.GetSection("spanish").Value;
-            var chinese_traditional = section.GetSection("chinese_traditional").Value;
-            var korean = section.GetSection("korean").Value;
-            var japanese = section.GetSection("japanese").Value;
+            var english = section.GetSection("english").ParseLocalization();
+            var french = section.GetSection("french").ParseLocalization();
+            var german = section.GetSection("german").ParseLocalization();
+            var russian = section.GetSection("russian").ParseLocalization();
+            var portuguese = section.GetSection("portuguese").ParseLocalization();
+            var chinese = section.GetSection("chinese").ParseLocalization();
+            var spanish = section.GetSection("spanish").ParseLocalization();
+            var chinese_traditional = section.GetSection("chinese_traditional").ParseLocalization();
+            var korean = section.GetSection("korean").ParseLocalization();
+            var japanese = section.GetSection("japanese").ParseLocalization();
             if (
                 key == null
                 && type == null

--- a/TrainworksReloaded.Base/Trait/CardTraitDataPipeline.cs
+++ b/TrainworksReloaded.Base/Trait/CardTraitDataPipeline.cs
@@ -137,7 +137,7 @@ namespace TrainworksReloaded.Base.Trait
                 .Field(typeof(CardTraitData), "paramInt3")
                 .SetValue(data, configuration.GetSection("param_int_3").ParseInt() ?? paramInt3);
 
-            var paramFloat = 0.0f;
+            var paramFloat = 1f;
             AccessTools
                 .Field(typeof(CardTraitData), "paramFloat")
                 .SetValue(data, configuration.GetSection("param_float").ParseFloat() ?? paramFloat);
@@ -161,7 +161,7 @@ namespace TrainworksReloaded.Base.Trait
                 .Field(typeof(CardTraitData), "paramBool")
                 .SetValue(data, configuration.GetSection("param_bool").ParseBool() ?? paramBool);
 
-            var traitIsRemovable = false;
+            var traitIsRemovable = true;
             AccessTools
                 .Field(typeof(CardTraitData), "traitIsRemovable")
                 .SetValue(

--- a/TrainworksReloaded.Base/Trait/CardTraitDataPipeline.cs
+++ b/TrainworksReloaded.Base/Trait/CardTraitDataPipeline.cs
@@ -142,7 +142,7 @@ namespace TrainworksReloaded.Base.Trait
                 .Field(typeof(CardTraitData), "paramFloat")
                 .SetValue(data, configuration.GetSection("param_float").ParseFloat() ?? paramFloat);
 
-            var subtype = "SubtypeData_None";
+            var subtype = "SubtypesData_None";
             AccessTools
                 .Field(typeof(CardTraitData), "paramSubtype")
                 .SetValue(data, configuration.GetSection("param_subtype").ParseString() ?? subtype);

--- a/schemas/schemas/cards.json
+++ b/schemas/schemas/cards.json
@@ -189,7 +189,7 @@
                     },
                     "targets_room": {
                         "type": "boolean",
-                        "description": "Whether this card targets an entire room."
+                        "description": "Whether this card targets an entire room. Defaults to true."
                     },
                     "traits": {
                         "type": "array",

--- a/schemas/schemas/effects.json
+++ b/schemas/schemas/effects.json
@@ -81,8 +81,8 @@
                         "description": "Minimum integer value for the effect."
                     },
                     "param_multipler": {
-                        "type": "integer",
-                        "description": "Multiplier parameter for the effect."
+                        "type": "number",
+                        "description": "Multiplier parameter for the effect. Defaults to 1.0"
                     },
                     "param_status_effects": {
                         "type": "array",
@@ -97,7 +97,7 @@
                     },
                     "param_subtypes": {
                         "$ref": "../definitions/subtype.json",
-                        "description": "Subtype parameter for the effect."
+                        "description": "Subtype parameter for the effect. Defaults to SubtypesData_None."
                     },
                     "param_trigger": {
                         "$ref": "../definitions/character_trigger.json",
@@ -156,7 +156,7 @@
                     },
                     "target_subtype": {
                         "$ref": "../definitions/subtype.json",
-                        "description": "Subtype to target."
+                        "description": "Subtype to target. Defaults to SubtypesData_None"
                     },
                     "target_team": {
                         "$ref": "../definitions/team.json",

--- a/schemas/schemas/traits.json
+++ b/schemas/schemas/traits.json
@@ -24,6 +24,10 @@
                         "type": "string",
                         "description": "The TraitStateName, this should be the name of a Class inheriting from CardTraitState. Trainworks will search your mod for the class, then the base game."
                     },
+                    "param_float": {
+                        "type": "number",
+                        "description": "Float parameter for the trait. Defaults to 1.0"
+                    },
                     "param_int": {
                         "type": "integer",
                         "description": "Integer parameter for the trait."
@@ -31,6 +35,10 @@
                     "track_type": {
                         "type": "string",
                         "description": "Type of tracking for the trait."
+                    },
+                    "trait_is_removable" {
+                        "type": "boolean",
+                        "description": "Determines if the trait can be removed via a CardUpgrade (remove_trait_upgrades). Defaults to true."
                     }
                 },
                 "description": "A trait definition that specifies the properties and behaviors of a trait that can be applied to cards."


### PR DESCRIPTION
## Summary
Bug fixes

## Changes
- Fix bug in cards.lore_tooltips parsing. If coming up with a new card the tooltips were never set in the card.
- Implement characters.character_lore_tooltips (Fixes lore tooltip NRE)
- Implement classes.starter_relics
- Fix #34 Enclose translations in "" if it contains a comma.
- Reasonable default values or make the default values line up with the codebase.

### Default value changes
- cards.targets_room = true
- effects.target_subtype = SubtypesData_None
- effects.param_subtype = SubtypesData_None
- effects.param_multiplier = 1.0
- traits.param_float = 1.0
- traits.trait_is_removable = true

## Checklist
[x] effects.param_multiplier was changed to number from integer.
[x] traits.parma_float Added
[x] traits.trait_is_removable Added

## Related Issues
#34 
