### PR TITLE
Add param_card_pool and implementation.

### DIFF
--- a/TrainworksReloaded.Base/Card/CardPoolRegister.cs
+++ b/TrainworksReloaded.Base/Card/CardPoolRegister.cs
@@ -8,11 +8,11 @@ using static RimLight;
 
 namespace TrainworksReloaded.Base.Card
 {
-    public class CardpoolRegister : Dictionary<string, CardPool>, IRegister<CardPool>
+    public class CardPoolRegister : Dictionary<string, CardPool>, IRegister<CardPool>
     {
-        private readonly IModLogger<CardpoolRegister> logger;
+        private readonly IModLogger<CardPoolRegister> logger;
 
-        public CardpoolRegister(GameDataClient client, IModLogger<CardpoolRegister> logger)
+        public CardPoolRegister(GameDataClient client, IModLogger<CardPoolRegister> logger)
         {
             this.logger = logger;
         }

--- a/TrainworksReloaded.Base/Effect/CardEffectFinalizer.cs
+++ b/TrainworksReloaded.Base/Effect/CardEffectFinalizer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using HarmonyLib;
+using TrainworksReloaded.Base.Card;
 using TrainworksReloaded.Base.Extensions;
 using TrainworksReloaded.Core.Extensions;
 using TrainworksReloaded.Core.Interfaces;
@@ -16,6 +17,7 @@ namespace TrainworksReloaded.Base.Effect
         private readonly IRegister<StatusEffectData> statusRegister;
         private readonly IRegister<CharacterTriggerData.Trigger> triggerEnumRegister;
         private readonly IRegister<CardUpgradeMaskData> upgradeMaskRegister;
+        private readonly IRegister<CardPool> cardPoolRegister;
         private readonly ICache<IDefinition<CardEffectData>> cache;
 
         public CardEffectFinalizer(
@@ -24,6 +26,7 @@ namespace TrainworksReloaded.Base.Effect
             IRegister<CardUpgradeMaskData> upgradeMaskRegister,
             IRegister<StatusEffectData> statusRegister,
             IRegister<CharacterTriggerData.Trigger> triggerEnumRegister,
+            IRegister<CardPool> cardPoolRegister,
             ICache<IDefinition<CardEffectData>> cache
         )
         {
@@ -32,6 +35,7 @@ namespace TrainworksReloaded.Base.Effect
             this.statusRegister = statusRegister;
             this.triggerEnumRegister = triggerEnumRegister;
             this.upgradeMaskRegister = upgradeMaskRegister;
+            this.cardPoolRegister = cardPoolRegister;
             this.cache = cache;
         }
 
@@ -209,7 +213,18 @@ namespace TrainworksReloaded.Base.Effect
                     filterId.ToId(key, TemplateConstants.UpgradeMask), 
                     out var lookup, 
                     out var _);
-                AccessTools.Field(typeof(CardUpgradeData), "paramCardFilter").SetValue(data, lookup);
+                AccessTools.Field(typeof(CardEffectData), "paramCardFilter").SetValue(data, lookup);
+            }
+
+            var cardPoolId = configuration.GetSection("param_card_pool")?.ParseString();
+            if (cardPoolId != null)
+            {
+                cardPoolRegister.TryLookupId(
+                    cardPoolId.ToId(key, TemplateConstants.CardPool),
+                    out var lookup,
+                    out var _
+                    );
+                AccessTools.Field(typeof(CardEffectData), "paramCardPool").SetValue(data, lookup);
             }
         }
     }

--- a/TrainworksReloaded.Base/Reward/RewardDataRegister.cs
+++ b/TrainworksReloaded.Base/Reward/RewardDataRegister.cs
@@ -9,9 +9,9 @@ namespace TrainworksReloaded.Base.Reward
 {
     public class RewardDataRegister : Dictionary<string, RewardData>, IRegister<RewardData>
     {
-        private readonly IModLogger<CardpoolRegister> logger;
+        private readonly IModLogger<CardPoolRegister> logger;
 
-        public RewardDataRegister(GameDataClient client, IModLogger<CardpoolRegister> logger)
+        public RewardDataRegister(GameDataClient client, IModLogger<CardPoolRegister> logger)
         {
             this.logger = logger;
         }

--- a/TrainworksReloaded.Plugin/RailheadPlugin.cs
+++ b/TrainworksReloaded.Plugin/RailheadPlugin.cs
@@ -309,8 +309,8 @@ namespace TrainworksReloaded.Plugin
                 >();
 
                 //register Card Pool
-                c.RegisterSingleton<IRegister<CardPool>, CardpoolRegister>(); //a place to register and access custom card data
-                c.RegisterSingleton<CardpoolRegister, CardpoolRegister>();
+                c.RegisterSingleton<IRegister<CardPool>, CardPoolRegister>(); //a place to register and access custom card data
+                c.RegisterSingleton<CardPoolRegister, CardPoolRegister>();
                 c.Register<IDataPipeline<IRegister<CardPool>, CardPool>, CardPoolPipeline>(); //a data pipeline to run as soon as register is needed
                 c.RegisterInitializer<IRegister<CardPool>>(x =>
                 {

--- a/schemas/schemas/effects.json
+++ b/schemas/schemas/effects.json
@@ -56,6 +56,10 @@
                         "type": "boolean",
                         "description": "Second boolean parameter for the effect."
                     },
+                    "param_card_pool": {
+                        "type": "string",
+                        "description": "Reference to CardPool for the effect."
+                    },
                     "param_character_data": {
                         "type": "string",
                         "description": "Reference to character data for the effect."


### PR DESCRIPTION
## Changes
- CardpoolRegister was misnamed, refactored to CardPoolRegister.
- param_card_filter processing had a copy/paste bug the AccessTools.Field will fail since it had `typeof(CardUpgradeData)`.
- Added CardPool parameter to CardEffectData.

## Test JSON
```
  "effects": [
    {
      "id": "AddBattleCard",
      "name": "CardEffectAddBattleCard",
      "param_int": 3,
      "param_int_2": 2,
      "param_card_pool": "@MyCardPool"
    }
  ],
```

## Checklist
- [x] effects.param_card_pool
