### PR TITLE
IRegister Refactor

### DIFF
--- a/TrainworksReloaded.Base/Card/CardDataRegister.cs
+++ b/TrainworksReloaded.Base/Card/CardDataRegister.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using HarmonyLib;
 using Malee;
+using TrainworksReloaded.Core.Enum;
 using TrainworksReloaded.Core.Interfaces;
 using UnityEngine;
 
@@ -68,21 +70,39 @@ namespace TrainworksReloaded.Base.Card
             return false;
         }
 
-        public bool TryLookupName(
-            string name,
-            [NotNullWhen(true)] out CardData? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
+        {
+            return identifierType switch
+            {
+                RegisterIdentifierType.ReadableID => [.. SaveManager.Value.GetAllGameData().GetAllCardData().Select(card => card.GetAssetKey())],
+                RegisterIdentifierType.GUID => [.. SaveManager.Value.GetAllGameData().GetAllCardData().Select(card => card.GetID())],
+                _ => [],
+            };
+        }
+
+        public bool TryLookupIdentifier(string identifier, RegisterIdentifierType identifierType, [NotNullWhen(true)] out CardData? lookup, [NotNullWhen(true)] out bool? IsModded)
         {
             lookup = null;
             IsModded = null;
             foreach (var card in SaveManager.Value.GetAllGameData().GetAllCardData())
             {
-                if (card.GetAssetKey().Equals(name, StringComparison.OrdinalIgnoreCase))
-                {
-                    lookup = card;
-                    IsModded = this.ContainsKey(card.name);
-                    return true;
+                switch (identifierType){
+                    case RegisterIdentifierType.ReadableID:
+                        if (card.GetAssetKey().Equals(identifier, StringComparison.OrdinalIgnoreCase))
+                        {
+                            lookup = card;
+                            IsModded = this.ContainsKey(card.name);
+                            return true;
+                        }
+                        break;
+                    case RegisterIdentifierType.GUID:
+                        if (card.GetID().Equals(identifier, StringComparison.OrdinalIgnoreCase))
+                        {
+                            lookup = card;
+                            IsModded = this.ContainsKey(card.name);
+                            return true;
+                        }
+                        break;
                 }
             }
             return false;

--- a/TrainworksReloaded.Base/Card/CardPoolRegister.cs
+++ b/TrainworksReloaded.Base/Card/CardPoolRegister.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using TrainworksReloaded.Base.CardUpgrade;
 using TrainworksReloaded.Core.Interfaces;
-using static RimLight;
+using TrainworksReloaded.Core.Enum;
 
 namespace TrainworksReloaded.Base.Card
 {
@@ -23,24 +23,21 @@ namespace TrainworksReloaded.Base.Card
             Add(key, item);
         }
 
-        public bool TryLookupId(
-            string id,
-            [NotNullWhen(true)] out CardPool? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
         {
-            IsModded = true;
-            return this.TryGetValue(id, out lookup);
+            return [.. this.Keys];
         }
 
-        public bool TryLookupName(
-            string name,
+        public bool TryLookupIdentifier(
+            string identifier,
+            RegisterIdentifierType identifierType,
             [NotNullWhen(true)] out CardPool? lookup,
             [NotNullWhen(true)] out bool? IsModded
         )
         {
             IsModded = true;
-            return this.TryGetValue(name, out lookup);
+            return this.TryGetValue(identifier, out lookup);
         }
     }
 }

--- a/TrainworksReloaded.Base/Character/CharacterDataRegister.cs
+++ b/TrainworksReloaded.Base/Character/CharacterDataRegister.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using HarmonyLib;
 using Malee;
+using TrainworksReloaded.Core.Enum;
 using TrainworksReloaded.Core.Interfaces;
 using UnityEngine;
 
@@ -32,6 +34,7 @@ namespace TrainworksReloaded.Base.Character
             this.logger = logger;
         }
 
+
         public void Register(string key, CharacterData item)
         {
             logger.Log(Core.Interfaces.LogLevel.Info, $"Register Character {key}... ");
@@ -42,45 +45,48 @@ namespace TrainworksReloaded.Base.Character
             CharacterDatas.Add(item);
             Add(key, item);
         }
+        
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
+        {
+            return identifierType switch
+            {
+                RegisterIdentifierType.ReadableID => [.. SaveManager.Value.GetAllGameData().GetAllCharacterData().Select(character => character.GetAssetKey())],
+                RegisterIdentifierType.GUID => [.. SaveManager.Value.GetAllGameData().GetAllCharacterData().Select(character => character.GetID())],
+                _ => [],
+            };
+        }
 
-        public bool TryLookupId(
-            string id,
-            [NotNullWhen(true)] out CharacterData? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+        public bool TryLookupIdentifier(string identifier, RegisterIdentifierType identifierType, [NotNullWhen(true)] out CharacterData? lookup, [NotNullWhen(true)] out bool? IsModded)
         {
             lookup = null;
             IsModded = null;
-            foreach (var card in SaveManager.Value.GetAllGameData().GetAllCharacterData())
+            switch (identifierType)
             {
-                if (card.GetID().Equals(id, StringComparison.OrdinalIgnoreCase))
-                {
-                    lookup = card;
-                    IsModded = this.ContainsKey(card.name);
-                    return true;
-                }
+                case RegisterIdentifierType.ReadableID:
+                    foreach (var card in SaveManager.Value.GetAllGameData().GetAllCharacterData())
+                    {
+                        if (card.GetAssetKey().Equals(identifier, StringComparison.OrdinalIgnoreCase))
+                        {
+                            lookup = card;
+                            IsModded = this.ContainsKey(card.name);
+                            return true;
+                        }
+                    }
+                    return false;
+                case RegisterIdentifierType.GUID:
+                    foreach (var card in SaveManager.Value.GetAllGameData().GetAllCharacterData())
+                    {
+                        if (card.GetID().Equals(identifier, StringComparison.OrdinalIgnoreCase))
+                        {
+                            lookup = card;
+                            IsModded = this.ContainsKey(card.name);
+                            return true;
+                        }
+                    }
+                    return false;
             }
             return false;
         }
 
-        public bool TryLookupName(
-            string name,
-            [NotNullWhen(true)] out CharacterData? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
-        {
-            lookup = null;
-            IsModded = null;
-            foreach (var card in SaveManager.Value.GetAllGameData().GetAllCharacterData())
-            {
-                if (card.GetAssetKey().Equals(name, StringComparison.OrdinalIgnoreCase))
-                {
-                    lookup = card;
-                    IsModded = this.ContainsKey(card.name);
-                    return true;
-                }
-            }
-            return false;
-        }
     }
 }

--- a/TrainworksReloaded.Base/Effect/CardEffectDataRegister.cs
+++ b/TrainworksReloaded.Base/Effect/CardEffectDataRegister.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using TrainworksReloaded.Core.Enum;
 using TrainworksReloaded.Core.Interfaces;
 
 namespace TrainworksReloaded.Base.Effect
@@ -15,38 +17,42 @@ namespace TrainworksReloaded.Base.Effect
             this.logger = logger;
         }
 
+
         public void Register(string key, CardEffectData item)
         {
             logger.Log(LogLevel.Info, $"Register Effect ({key})");
             Add(key, item);
         }
 
-        public bool TryLookupId(
-            string id,
-            [NotNullWhen(true)] out CardEffectData? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
         {
-            IsModded = true;
-            return this.TryGetValue(id, out lookup);
+            return identifierType switch
+            {
+                RegisterIdentifierType.ReadableID => [.. this.Values.Select(effect => effect.GetEffectStateName())],
+                RegisterIdentifierType.GUID => [.. this.Keys],
+                _ => []
+            };
         }
-
-        public bool TryLookupName(
-            string name,
-            [NotNullWhen(true)] out CardEffectData? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+        public bool TryLookupIdentifier(string identifier, RegisterIdentifierType identifierType, [NotNullWhen(true)] out CardEffectData? lookup, [NotNullWhen(true)] out bool? IsModded)
         {
             lookup = null;
             IsModded = true;
-            foreach (var effect in this.Values)
+            switch (identifierType)
             {
-                if (effect.GetEffectStateName() == name)
-                {
-                    lookup = effect;
+                case RegisterIdentifierType.ReadableID:
+                    foreach (var effect in this.Values)
+                    {
+                        if (effect.GetEffectStateName() == identifier)
+                        {
+                            lookup = effect;
+                            IsModded = true;
+                            return true;
+                        }
+                    }
+                    return false;
+                case RegisterIdentifierType.GUID:
                     IsModded = true;
-                    return true;
-                }
+                    return this.TryGetValue(identifier, out lookup);
             }
             return false;
         }

--- a/TrainworksReloaded.Base/Enums/CardTriggerTypeRegister.cs
+++ b/TrainworksReloaded.Base/Enums/CardTriggerTypeRegister.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using TrainworksReloaded.Base.Effect;
+using TrainworksReloaded.Core.Enum;
 using TrainworksReloaded.Core.Interfaces;
 using static CharacterTriggerData;
 using static RimLight;
@@ -21,31 +22,36 @@ namespace TrainworksReloaded.Base.Enums
             this.logger = logger;
         }
 
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
+        {
+            return identifierType switch
+            {
+                RegisterIdentifierType.ReadableID => [.. this.Keys],
+                RegisterIdentifierType.GUID => [.. this.Keys],
+                _ => []
+            };
+        }
+
         public void Register(string key, CardTriggerType item)
         {
             logger.Log(LogLevel.Info, $"Register Card Trigger Enum ({key})");
-
             Add(key, item);
         }
 
-        public bool TryLookupId(
-            string id,
-            [NotNullWhen(true)] out CardTriggerType lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+        public bool TryLookupIdentifier(string identifier, RegisterIdentifierType identifierType, [NotNullWhen(true)] out CardTriggerType lookup, [NotNullWhen(true)] out bool? IsModded)
         {
+            lookup = default;
             IsModded = true;
-            return this.TryGetValue(id, out lookup);
+            switch (identifierType)
+            {
+                case RegisterIdentifierType.ReadableID:
+                    return this.TryGetValue(identifier, out lookup);
+                case RegisterIdentifierType.GUID:
+                    return this.TryGetValue(identifier, out lookup);
+                default:
+                    return false;
+            }
         }
 
-        public bool TryLookupName(
-            string name,
-            [NotNullWhen(true)] out CardTriggerType lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
-        {
-            IsModded = true;
-            return this.TryGetValue(name, out lookup);
-        }
     }
 }

--- a/TrainworksReloaded.Base/Enums/CharacterTriggerTypeRegister.cs
+++ b/TrainworksReloaded.Base/Enums/CharacterTriggerTypeRegister.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using TrainworksReloaded.Base.Effect;
 using TrainworksReloaded.Base.Trigger;
+using TrainworksReloaded.Core.Enum;
 using TrainworksReloaded.Core.Interfaces;
 
 namespace TrainworksReloaded.Base.Enums
@@ -19,30 +20,36 @@ namespace TrainworksReloaded.Base.Enums
             this.logger = logger;
         }
 
+
         public void Register(string key, CharacterTriggerData.Trigger item)
         {
             logger.Log(LogLevel.Info, $"Register Character Trigger Enum ({key})");
             Add(key, item);
         }
 
-        public bool TryLookupId(
-            string id,
-            [NotNullWhen(true)] out CharacterTriggerData.Trigger lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
         {
-            IsModded = true;
-            return TryGetValue(id, out lookup);
+            return identifierType switch
+            {
+                RegisterIdentifierType.ReadableID => [.. this.Keys],
+                RegisterIdentifierType.GUID => [.. this.Keys],
+                _ => []
+            };
         }
 
-        public bool TryLookupName(
-            string name,
-            [NotNullWhen(true)] out CharacterTriggerData.Trigger lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+        public bool TryLookupIdentifier(string identifier, RegisterIdentifierType identifierType, [NotNullWhen(true)] out CharacterTriggerData.Trigger lookup, [NotNullWhen(true)] out bool? IsModded)
         {
+            lookup = default;
             IsModded = true;
-            return this.TryGetValue(name, out lookup);
+            switch (identifierType)
+            {
+                case RegisterIdentifierType.ReadableID:
+                    return this.TryGetValue(identifier, out lookup);
+                case RegisterIdentifierType.GUID:
+                    return this.TryGetValue(identifier, out lookup);
+                default:
+                    return false;
+            }
         }
     }
 }

--- a/TrainworksReloaded.Base/Localization/CustomLocalizationTermRegistry.cs
+++ b/TrainworksReloaded.Base/Localization/CustomLocalizationTermRegistry.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using I2.Loc;
+using TrainworksReloaded.Core.Enum;
 using TrainworksReloaded.Core.Interfaces;
 
 namespace TrainworksReloaded.Base.Localization
@@ -55,22 +56,29 @@ namespace TrainworksReloaded.Base.Localization
             }
         }
 
-        public bool TryLookupName(
-            string name,
-            [NotNullWhen(true)] out LocalizationTerm? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
         {
-            throw new NotImplementedException();
+            return identifierType switch
+            {
+                RegisterIdentifierType.ReadableID => [.. this.Keys],
+                RegisterIdentifierType.GUID => [.. this.Keys],
+                _ => []
+            };
         }
 
-        public bool TryLookupId(
-            string id,
-            [NotNullWhen(true)] out LocalizationTerm? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+        public bool TryLookupIdentifier(string identifier, RegisterIdentifierType identifierType, [NotNullWhen(true)] out LocalizationTerm? lookup, [NotNullWhen(true)] out bool? IsModded)
         {
-            throw new NotImplementedException();
+            lookup = null;
+            IsModded = true;
+            switch (identifierType)
+            {
+                case RegisterIdentifierType.ReadableID:
+                    return this.TryGetValue(identifier, out lookup);
+                case RegisterIdentifierType.GUID:
+                    return this.TryGetValue(identifier, out lookup);
+                default:
+                    return false;
+            }
         }
     }
 }

--- a/TrainworksReloaded.Base/Prefab/GameObjectRegister.cs
+++ b/TrainworksReloaded.Base/Prefab/GameObjectRegister.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Xml.Linq;
+using TrainworksReloaded.Core.Enum;
 using TrainworksReloaded.Core.Interfaces;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
@@ -162,35 +163,38 @@ namespace TrainworksReloaded.Base.Prefab
             this.Add(key, item);
         }
 
-        public bool TryLookupId(
-            string id,
-            [NotNullWhen(true)] out GameObject? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
         {
-            IsModded = true;
-            return this.TryGetValue(id, out lookup);
+            return identifierType switch
+            {
+                RegisterIdentifierType.ReadableID => [.. this.Select(gameobject => gameobject.Key)],
+                RegisterIdentifierType.GUID => [.. this.Keys],
+                _ => [],
+            };
         }
 
-        public bool TryLookupName(
-            string name,
-            [NotNullWhen(true)] out GameObject? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+        public bool TryLookupIdentifier(string identifier, RegisterIdentifierType identifierType, [NotNullWhen(true)] out GameObject? lookup, [NotNullWhen(true)] out bool? IsModded)
         {
             lookup = null;
             IsModded = true;
-            foreach (var gameobject in this.Values)
+            switch (identifierType)
             {
-                if (gameobject.name == name)
-                {
-                    lookup = gameobject;
-                    IsModded = true;
-                    return true;
-                }
+                case RegisterIdentifierType.ReadableID:
+                    foreach (var gameobject in this.Values)
+                    {
+                        if (gameobject.name == identifier)
+                        {
+                            lookup = gameobject;
+                            IsModded = true;
+                            return true;
+                        }
+                    }
+                    return false;
+                case RegisterIdentifierType.GUID:
+                    return this.TryGetValue(identifier, out lookup);
+                default:
+                    return false;
             }
-
-            return false;
         }
     }
 }

--- a/TrainworksReloaded.Base/Prefab/SpriteRegister.cs
+++ b/TrainworksReloaded.Base/Prefab/SpriteRegister.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text;
+using TrainworksReloaded.Core.Enum;
 using TrainworksReloaded.Core.Interfaces;
 using UnityEngine;
 using UnityEngine.AddressableAssets.ResourceLocators;
@@ -18,40 +20,46 @@ namespace TrainworksReloaded.Base.Prefab
             this.logger = logger;
         }
 
+
         public void Register(string key, Sprite item)
         {
             logger.Log(LogLevel.Info, $"Register Sprite ({key})");
             this.Add(key, item);
         }
 
-        public bool TryLookupId(
-            string id,
-            [NotNullWhen(true)] out Sprite? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
         {
-            IsModded = true;
-            return this.TryGetValue(id, out lookup);
+            return identifierType switch
+            {
+                RegisterIdentifierType.ReadableID => [.. this.Values.Select(sprite => sprite.name)],
+                RegisterIdentifierType.GUID => [.. this.Keys],
+                _ => [],
+            };
         }
 
-        public bool TryLookupName(
-            string name,
-            [NotNullWhen(true)] out Sprite? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+        public bool TryLookupIdentifier(string identifier, RegisterIdentifierType identifierType, [NotNullWhen(true)] out Sprite? lookup, [NotNullWhen(true)] out bool? IsModded)
         {
             lookup = null;
             IsModded = true;
-            foreach (var sprite in this.Values)
+            switch (identifierType)
             {
-                if (sprite.name == name)
-                {
-                    lookup = sprite;
-                    IsModded = true;
-                    return true;
-                }
+                case RegisterIdentifierType.ReadableID:
+                    foreach (var sprite in this.Values)
+                    {
+                        if (sprite.name == identifier)
+                        {
+                            lookup = sprite;
+                            IsModded = true;
+                            return true;
+                        }
+                    }
+                    return false;
+                case RegisterIdentifierType.GUID:
+                    return this.TryGetValue(identifier, out lookup);
+                default:
+                    return false;
             }
-            return false;
         }
+
     }
 }

--- a/TrainworksReloaded.Base/Prefab/VfxFinalizer.cs
+++ b/TrainworksReloaded.Base/Prefab/VfxFinalizer.cs
@@ -4,6 +4,7 @@ using System.Text;
 using HarmonyLib;
 using TrainworksReloaded.Base.Character;
 using TrainworksReloaded.Base.Extensions;
+using TrainworksReloaded.Core.Extensions;
 using TrainworksReloaded.Core.Interfaces;
 using UnityEngine.AddressableAssets;
 

--- a/TrainworksReloaded.Base/Prefab/VfxRegister.cs
+++ b/TrainworksReloaded.Base/Prefab/VfxRegister.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.Text;
 using HarmonyLib;
+using TrainworksReloaded.Core.Enum;
 using TrainworksReloaded.Core.Interfaces;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
@@ -45,36 +46,42 @@ namespace TrainworksReloaded.Base.Prefab
             this.Add(key, item);
         }
 
-        public bool TryLookupId(
-            string id,
-            [NotNullWhen(true)] out VfxAtLoc? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
         {
-            IsModded = true;
-            var result = this.TryGetValue(id, out lookup);
-            if (result == false)
+            return identifierType switch
             {
-                lookup = Default;
-                result = true;
-            }
-            return result;
+                RegisterIdentifierType.ReadableID => [.. this.Keys],
+                RegisterIdentifierType.GUID => [.. this.Keys],
+                _ => [],
+            };
         }
 
-        public bool TryLookupName(
-            string name,
-            [NotNullWhen(true)] out VfxAtLoc? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+        public bool TryLookupIdentifier(string identifier, RegisterIdentifierType identifierType, [NotNullWhen(true)] out VfxAtLoc? lookup, [NotNullWhen(true)] out bool? IsModded)
         {
+            lookup = null;
             IsModded = true;
-            var result = this.TryGetValue(name, out lookup);
-            if (result == false)
+            switch (identifierType)
             {
-                lookup = Default;
-                result = true;
+                case RegisterIdentifierType.ReadableID:
+                    var result = this.TryGetValue(identifier, out lookup);
+                    if (result == false)
+                    {
+                        lookup = Default;
+                        result = true;
+                    }
+                    return result;
+                case RegisterIdentifierType.GUID:
+                    var result2 = this.TryGetValue(identifier, out lookup);
+                    if (result2 == false)
+                    {
+                        lookup = Default;
+                        result2 = true;
+                    }
+                    return result2;
+                default:
+                    return false;
             }
-            return result;
         }
     }
 }

--- a/TrainworksReloaded.Base/Relic/RelicDataRegister.cs
+++ b/TrainworksReloaded.Base/Relic/RelicDataRegister.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
+using TrainworksReloaded.Core.Enum;
 using TrainworksReloaded.Core.Interfaces;
 
 namespace TrainworksReloaded.Base.Relic
@@ -27,6 +28,16 @@ namespace TrainworksReloaded.Base.Relic
             this.logger = logger;
         }
 
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
+        {
+            return identifierType switch
+            {
+                RegisterIdentifierType.ReadableID => [.. this.Keys],
+                RegisterIdentifierType.GUID => [.. this.Keys],
+                _ => [],
+            };
+        }
+
         public void Register(string key, RelicData item)
         {
             logger.Log(Core.Interfaces.LogLevel.Info, $"Register Relic {key}... ");
@@ -41,16 +52,19 @@ namespace TrainworksReloaded.Base.Relic
             Add(key, item);
         }
 
-        public bool TryLookupId(string id, [NotNullWhen(true)] out RelicData? lookup, [NotNullWhen(true)] out bool? IsModded)
+        public bool TryLookupIdentifier(string identifier, RegisterIdentifierType identifierType, [NotNullWhen(true)] out RelicData? lookup, [NotNullWhen(true)] out bool? IsModded)
         {
+            lookup = null;
             IsModded = true;
-            return this.TryGetValue(id, out lookup);
-        }
-
-        public bool TryLookupName(string name, [NotNullWhen(true)] out RelicData? lookup, [NotNullWhen(true)] out bool? IsModded)
-        {
-            IsModded = true;
-            return this.TryGetValue(name, out lookup);
+            switch (identifierType)
+            {
+                case RegisterIdentifierType.ReadableID:
+                    return this.TryGetValue(identifier, out lookup);
+                case RegisterIdentifierType.GUID:
+                    return this.TryGetValue(identifier, out lookup);
+                default:
+                    return false;
+            }
         }
     }
 }

--- a/TrainworksReloaded.Base/Relic/RelicEffectDataFinalizer.cs
+++ b/TrainworksReloaded.Base/Relic/RelicEffectDataFinalizer.cs
@@ -147,7 +147,7 @@ namespace TrainworksReloaded.Base.Relic
                 if (idConfig == null) continue;
 
                 var id = idConfig.ToId(key, TemplateConstants.Character);
-                if (characterRegister.TryLookupId(id, out var character, out var _))
+                if (characterRegister.TryLookupName(id, out var character, out var _))
                 {
                     characters.Add(character);
                 }

--- a/TrainworksReloaded.Base/Relic/RelicEffectDataRegister.cs
+++ b/TrainworksReloaded.Base/Relic/RelicEffectDataRegister.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using TrainworksReloaded.Core.Enum;
 using TrainworksReloaded.Core.Interfaces;
 
 namespace TrainworksReloaded.Base.Relic
@@ -14,22 +15,37 @@ namespace TrainworksReloaded.Base.Relic
             this.logger = logger;
         }
 
+
         public void Register(string key, RelicEffectData item)
         {
             logger.Log(Core.Interfaces.LogLevel.Info, $"Register RelicEffect {key}... ");
             Add(key, item);
         }
 
-        public bool TryLookupId(string id, [NotNullWhen(true)] out RelicEffectData? lookup, [NotNullWhen(true)] out bool? IsModded)
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
         {
+            return identifierType switch
+            {
+                RegisterIdentifierType.ReadableID => [.. this.Keys],
+                RegisterIdentifierType.GUID => [.. this.Keys],
+                _ => [],
+            };
+        }
+        
+        public bool TryLookupIdentifier(string identifier, RegisterIdentifierType identifierType, [NotNullWhen(true)] out RelicEffectData? lookup, [NotNullWhen(true)] out bool? IsModded)
+        {
+            lookup = null;
             IsModded = true;
-            return this.TryGetValue(id, out lookup);
+            switch (identifierType)
+            {
+                case RegisterIdentifierType.ReadableID:
+                    return this.TryGetValue(identifier, out lookup);
+                case RegisterIdentifierType.GUID:
+                    return this.TryGetValue(identifier, out lookup);
+                default:
+                    return false;
+            }
         }
 
-        public bool TryLookupName(string name, [NotNullWhen(true)] out RelicEffectData? lookup, [NotNullWhen(true)] out bool? IsModded)
-        {
-            IsModded = true;
-            return this.TryGetValue(name, out lookup);
-        }
     }
-} 
+}

--- a/TrainworksReloaded.Base/Reward/RewardDataRegister.cs
+++ b/TrainworksReloaded.Base/Reward/RewardDataRegister.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using TrainworksReloaded.Base.Card;
+using TrainworksReloaded.Core.Enum;
 using TrainworksReloaded.Core.Interfaces;
 
 namespace TrainworksReloaded.Base.Reward
@@ -16,30 +17,38 @@ namespace TrainworksReloaded.Base.Reward
             this.logger = logger;
         }
 
+
         public void Register(string key, RewardData item)
         {
             logger.Log(Core.Interfaces.LogLevel.Info, $"Register Reward {key}... ");
             Add(key, item);
         }
 
-        public bool TryLookupId(
-            string id,
-            [NotNullWhen(true)] out RewardData? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
         {
+            return identifierType switch
+            {
+                RegisterIdentifierType.ReadableID => [.. this.Keys],
+                RegisterIdentifierType.GUID => [.. this.Keys],
+                _ => [],
+            };
+        }
+        
+        public bool TryLookupIdentifier(string identifier, RegisterIdentifierType identifierType, [NotNullWhen(true)] out RewardData? lookup, [NotNullWhen(true)] out bool? IsModded)
+        {
+            lookup = null;
             IsModded = true;
-            return this.TryGetValue(id, out lookup);
+            switch (identifierType)
+            {
+                case RegisterIdentifierType.ReadableID:
+                    return this.TryGetValue(identifier, out lookup);
+                case RegisterIdentifierType.GUID:
+                    return this.TryGetValue(identifier, out lookup);
+                default:
+                    return false;
+            }
         }
 
-        public bool TryLookupName(
-            string name,
-            [NotNullWhen(true)] out RewardData? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
-        {
-            IsModded = true;
-            return this.TryGetValue(name, out lookup);
-        }
     }
 }

--- a/TrainworksReloaded.Base/Room/RoomModifierRegister.cs
+++ b/TrainworksReloaded.Base/Room/RoomModifierRegister.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using TrainworksReloaded.Base.Trait;
+using TrainworksReloaded.Core.Enum;
 using TrainworksReloaded.Core.Interfaces;
-using static RimLight;
 
 namespace TrainworksReloaded.Base.Room
 {
@@ -25,24 +25,31 @@ namespace TrainworksReloaded.Base.Room
             Add(key, item);
         }
 
-        public bool TryLookupId(
-            string id,
-            [NotNullWhen(true)] out RoomModifierData? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
         {
-            IsModded = true;
-            return this.TryGetValue(id, out lookup);
+            return identifierType switch
+            {
+                RegisterIdentifierType.ReadableID => [.. this.Keys],
+                RegisterIdentifierType.GUID => [.. this.Keys],
+                _ => [],
+            };
         }
 
-        public bool TryLookupName(
-            string name,
-            [NotNullWhen(true)] out RoomModifierData? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+        public bool TryLookupIdentifier(string identifier, RegisterIdentifierType identifierType, [NotNullWhen(true)] out RoomModifierData? lookup, [NotNullWhen(true)] out bool? IsModded)
         {
+            lookup = null;
             IsModded = true;
-            return this.TryGetValue(name, out lookup);
+            switch (identifierType)
+            {
+                case RegisterIdentifierType.ReadableID:
+                    return this.TryGetValue(identifier, out lookup);
+                case RegisterIdentifierType.GUID:
+                    return this.TryGetValue(identifier, out lookup);
+                default:
+                    return false;
+            }
         }
+
     }
 }

--- a/TrainworksReloaded.Base/StatusEffects/StatusEffectDataRegister.cs
+++ b/TrainworksReloaded.Base/StatusEffects/StatusEffectDataRegister.cs
@@ -3,9 +3,11 @@ using Malee;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text;
 using TrainworksReloaded.Base.Card;
 using TrainworksReloaded.Base.Effect;
+using TrainworksReloaded.Core.Enum;
 using TrainworksReloaded.Core.Interfaces;
 using UnityEngine;
 
@@ -28,33 +30,38 @@ namespace TrainworksReloaded.Base.StatusEffects
             Add(key, item);
         }
 
-        public bool TryLookupId(
-            string id,
-            [NotNullWhen(true)] out StatusEffectData? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
         {
-            IsModded = true;
-            return this.TryGetValue(id, out lookup);
+            return identifierType switch
+            {
+                RegisterIdentifierType.ReadableID => [.. this.Values.Select(effect => effect.GetStatusId())],
+                RegisterIdentifierType.GUID => [.. this.Keys],
+                _ => [],
+            };
         }
 
-        public bool TryLookupName(
-            string name,
-            [NotNullWhen(true)] out StatusEffectData? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        )
+
+        public bool TryLookupIdentifier(string identifier, RegisterIdentifierType identifierType, [NotNullWhen(true)] out StatusEffectData? lookup, [NotNullWhen(true)] out bool? IsModded)
         {
             lookup = null;
             IsModded = true;
-            foreach (var effect in this.Values)
+            switch (identifierType)
             {
-                if (effect.GetStatusId() == name)
-                {
-                    lookup = effect;
-                    return true;
-                }
+                case RegisterIdentifierType.ReadableID:
+                    foreach (var effect in this.Values)
+                    {
+                        if (effect.GetStatusId() == identifier)
+                        {
+                            lookup = effect;
+                            return true;
+                        }
+                    }
+                    return false;
+                case RegisterIdentifierType.GUID:
+                    return this.TryGetValue(identifier, out lookup);
+                default:
+                    return false;
             }
-            return false;
         }
     }
 }

--- a/TrainworksReloaded.Core/Enum/RegisterIdentifier.cs
+++ b/TrainworksReloaded.Core/Enum/RegisterIdentifier.cs
@@ -1,0 +1,8 @@
+namespace TrainworksReloaded.Core.Enum
+{
+    public enum RegisterIdentifierType
+    {
+        ReadableID,
+        GUID
+    }
+}

--- a/TrainworksReloaded.Core/Extensions/RegisterExtensions.cs
+++ b/TrainworksReloaded.Core/Extensions/RegisterExtensions.cs
@@ -1,0 +1,43 @@
+
+using System.Diagnostics.CodeAnalysis;
+using TrainworksReloaded.Core.Enum;
+using TrainworksReloaded.Core.Interfaces;
+
+namespace TrainworksReloaded.Core.Extensions
+{
+    public static class RegisterExtensions
+    {
+        /// <summary>
+        /// Try to lookup an item by name
+        /// A Name is a human readable identifier for an item
+        /// </summary>
+        /// <param name="name">The name of the item to lookup</param>
+        /// <param name="lookup">The item if found</param>
+        /// <param name="IsModded">Whether the item is modded</param>
+        public static bool TryLookupName<T>(
+            this IRegister<T> register,
+            string name,
+            [NotNullWhen(true)] out T? lookup,
+            [NotNullWhen(true)] out bool? IsModded
+        )
+        {
+            return register.TryLookupIdentifier(name, RegisterIdentifierType.ReadableID, out lookup, out IsModded);
+        }
+        /// <summary>
+        /// Try to lookup an item by id
+        /// An Id is a unique identifier for an item that is not guaranteed to be human readable. 
+        /// </summary>
+        /// <param name="id">The id of the item to lookup</param>
+        /// <param name="lookup">The item if found</param>
+        /// <param name="IsModded">Whether the item is modded</param>
+        public static bool TryLookupId<T>(
+            this IRegister<T> register,
+            string id,
+            [NotNullWhen(true)] out T? lookup,
+            [NotNullWhen(true)] out bool? IsModded
+        )
+        {
+            return register.TryLookupIdentifier(id, RegisterIdentifierType.GUID, out lookup, out IsModded);
+        }
+    }
+}

--- a/TrainworksReloaded.Core/Interfaces/IRegister.cs
+++ b/TrainworksReloaded.Core/Interfaces/IRegister.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using TrainworksReloaded.Core.Enum;
 
 namespace TrainworksReloaded.Core.Interfaces
 {
@@ -8,13 +9,23 @@ namespace TrainworksReloaded.Core.Interfaces
     /// <typeparam name="T"></typeparam>
     public interface IRegister<T> : IRegisterableDictionary<T>
     {
-        public bool TryLookupName(
-            string name,
-            [NotNullWhen(true)] out T? lookup,
-            [NotNullWhen(true)] out bool? IsModded
-        );
-        public bool TryLookupId(
-            string id,
+        /// <summary>
+        /// gets all stored identifiers of a given identifier type
+        /// </summary>
+        /// <param name="identifierType">The type of identifier to get</param>
+        /// <returns>A list of all identifiers of the given type</returns>
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType);
+
+        /// <summary>
+        /// attempts to get a stored lookup item by identifier
+        /// </summary>
+        /// <param name="identifier">The identifier of the item to lookup</param>
+        /// <param name="identifierType">The type of identifier to lookup</param>
+        /// <param name="lookup">The item if found</param>
+        /// <param name="IsModded">Whether the item is modded</param>
+        public bool TryLookupIdentifier(
+            string identifier,
+            RegisterIdentifierType identifierType,
             [NotNullWhen(true)] out T? lookup,
             [NotNullWhen(true)] out bool? IsModded
         );

--- a/TrainworksReloaded.Test/CardTests.cs
+++ b/TrainworksReloaded.Test/CardTests.cs
@@ -5,6 +5,7 @@ using SimpleInjector;
 using TrainworksReloaded.Base;
 using TrainworksReloaded.Base.Card;
 using TrainworksReloaded.Base.Localization;
+using TrainworksReloaded.Core.Enum;
 using TrainworksReloaded.Core.Impl;
 using TrainworksReloaded.Core.Interfaces;
 using TrainworksReloaded.Plugin;
@@ -58,14 +59,15 @@ namespace TrainworksReloaded.Test
             // TryLookupName
             termRegister
                 .Setup(tr =>
-                    tr.TryLookupName(
+                    tr.TryLookupIdentifier(
                         It.IsAny<string>(),
+                        It.IsAny<RegisterIdentifierType>(),
                         out It.Ref<LocalizationTerm?>.IsAny,
                         out It.Ref<bool?>.IsAny
                     )
                 )
                 .Returns(
-                    (string name, out LocalizationTerm? term, out bool? isModded) =>
+                    (string name, RegisterIdentifierType identifierType, out LocalizationTerm? term, out bool? isModded) =>
                     {
                         term = TermDictionary.Values.FirstOrDefault(t => t.English == name);
                         isModded = false;
@@ -76,14 +78,15 @@ namespace TrainworksReloaded.Test
             // TryLookupId
             termRegister
                 .Setup(tr =>
-                    tr.TryLookupId(
+                    tr.TryLookupIdentifier(
                         It.IsAny<string>(),
+                        It.IsAny<RegisterIdentifierType>(),
                         out It.Ref<LocalizationTerm?>.IsAny,
                         out It.Ref<bool?>.IsAny
                     )
                 )
                 .Returns(
-                    (string id, out LocalizationTerm? term, out bool? isModded) =>
+                    (string id, RegisterIdentifierType identifierType, out LocalizationTerm? term, out bool? isModded) =>
                     {
                         term = TermDictionary.ContainsKey(id) ? TermDictionary[id] : null;
                         isModded = false;
@@ -235,14 +238,15 @@ namespace TrainworksReloaded.Test
             var mockCardRegister = new Mock<IRegister<CardData>>();
             mockCardRegister
                 .Setup(cr =>
-                    cr.TryLookupName(
+                    cr.TryLookupIdentifier(
                         "fire_starter",
+                        It.IsAny<RegisterIdentifierType>(),
                         out It.Ref<CardData?>.IsAny,
                         out It.Ref<bool?>.IsAny
                     )
                 )
                 .Returns(
-                    (string _, out CardData? card, out bool? modded) =>
+                    (string _, RegisterIdentifierType identifierType, out CardData? card, out bool? modded) =>
                     {
                         modded = true;
                         card = existingCard;


### PR DESCRIPTION
Refactored IRegister to be more generalized and allow for Getting all keys

## Summary
Updated IRegister to be reduce functional complexity and increase usefulness with ability to get all identifiers. Should make certain future applications more dependable.

## Changes
- Remove IRegister LookupName and LookUpID, made into extension functions to LookUpIdentifier
- Added a way of getting all available identifiers.

