### PR TITLE
#14 Add CharacterChatter processors.

### DIFF
--- a/TrainworksReloaded.Base/Character/CharacterChatterDefinition.cs
+++ b/TrainworksReloaded.Base/Character/CharacterChatterDefinition.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using TrainworksReloaded.Core.Interfaces;
+
+namespace TrainworksReloaded.Base.Character
+{
+    public class CharacterChatterDefinition(
+        string key,
+        CharacterChatterData data,
+        IConfiguration configuration
+    ) : IDefinition<CharacterChatterData>
+    {
+        public string Key { get; set; } = key;
+        public CharacterChatterData Data { get; set; } = data;
+        public IConfiguration Configuration { get; set; } = configuration;
+        public string Id { get; set; } = "";
+        public bool IsModded => true;
+    }
+}

--- a/TrainworksReloaded.Base/Character/CharacterChatterFinalizer.cs
+++ b/TrainworksReloaded.Base/Character/CharacterChatterFinalizer.cs
@@ -1,0 +1,107 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml.Linq;
+using TrainworksReloaded.Base.Extensions;
+using TrainworksReloaded.Base.Localization;
+using TrainworksReloaded.Base.Prefab;
+using TrainworksReloaded.Core.Extensions;
+using TrainworksReloaded.Core.Interfaces;
+using UnityEngine.AddressableAssets;
+using static CharacterChatterData;
+
+namespace TrainworksReloaded.Base.Character
+{
+    public class CharacterChatterFinalizer : IDataFinalizer
+    {
+        private readonly IModLogger<CharacterChatterFinalizer> logger;
+        private readonly ICache<IDefinition<CharacterChatterData>> cache;
+        private readonly IRegister<CharacterTriggerData.Trigger> triggerEnumRegister;
+        private readonly IRegister<CharacterChatterData> chatterRegister;
+        private readonly IRegister<LocalizationTerm> termRegister;
+        
+        public CharacterChatterFinalizer(
+            IModLogger<CharacterChatterFinalizer> logger,
+            ICache<IDefinition<CharacterChatterData>> cache,
+            IRegister<CharacterTriggerData.Trigger> triggerEnumRegister,
+            IRegister<CharacterChatterData> chatterRegister,
+            IRegister<LocalizationTerm> termRegister
+        )
+        {
+            this.logger = logger;
+            this.cache = cache;
+            this.triggerEnumRegister = triggerEnumRegister;
+            this.chatterRegister = chatterRegister;
+            this.termRegister = termRegister;
+        }
+
+        public void FinalizeData()
+        {
+            foreach (var definition in cache.GetCacheItems())
+            {
+                FinalizeCharacterChatterData(definition);
+            }
+            cache.Clear();
+        }
+
+        public void FinalizeCharacterChatterData(IDefinition<CharacterChatterData> definition)
+        {
+            var configuration = definition.Configuration;
+            var data = definition.Data;
+            var key = definition.Key;
+            var name = data.name;
+
+            logger.Log(Core.Interfaces.LogLevel.Info, $"Finalizing Character Chatter {data.name}... ");
+
+            int i = 0;
+            List<TriggerChatterExpressionData> triggerExpressions = [];
+            foreach (var child in configuration.GetSection("trigger_expressions").GetChildren())
+            {
+                var trigger = CharacterTriggerData.Trigger.OnDeath;
+                var triggerSection = configuration.GetSection("trigger");
+                if (triggerSection.Value != null)
+                {
+                    var value = triggerSection.Value;
+                    if (
+                        triggerEnumRegister.TryLookupId(
+                            value.ToId(key, TemplateConstants.CharacterTriggerEnum),
+                            out var triggerFound,
+                            out var _
+                        )
+                    )
+                    {
+                        trigger = triggerFound;
+                    }
+                    else
+                    {
+                        trigger = triggerSection.ParseTrigger() ?? default;
+                    }
+                }
+
+                var term = child.GetSection("expressiosn").ParseLocalizationTerm();
+                if (term != null)
+                {
+                    term.Key = $"CharacterChatterData_triggerExpressions{i}-{name}";
+                    termRegister.Add(term.Key, term);
+                    triggerExpressions.Add(new TriggerChatterExpressionData
+                    {
+                        trigger = trigger,
+                        locKey = term.Key,
+                    });
+                }
+                i++;
+            }
+            AccessTools.Field(typeof(CharacterChatterData), "characterTriggerExpressions").SetValue(data, triggerExpressions);
+
+            var chatterId = configuration.GetSection("base_chatter").ParseString();
+            if (chatterId != null)
+            {
+                if (chatterRegister.TryLookupId(chatterId.ToId(key, TemplateConstants.Chatter), out var lookup, out var _))
+                { 
+                    AccessTools.Field(typeof(CharacterChatterData), "baseData").SetValue(data, lookup);
+                }
+            }
+        }
+    }
+}

--- a/TrainworksReloaded.Base/Character/CharacterChatterFinalizer.cs
+++ b/TrainworksReloaded.Base/Character/CharacterChatterFinalizer.cs
@@ -79,7 +79,7 @@ namespace TrainworksReloaded.Base.Character
                     }
                 }
 
-                var term = child.GetSection("expressiosn").ParseLocalizationTerm();
+                var term = child.GetSection("expressions").ParseLocalizationTerm();
                 if (term != null)
                 {
                     term.Key = $"CharacterChatterData_triggerExpressions{i}-{name}";

--- a/TrainworksReloaded.Base/Character/CharacterChatterPipeline.cs
+++ b/TrainworksReloaded.Base/Character/CharacterChatterPipeline.cs
@@ -1,0 +1,168 @@
+﻿using HarmonyLib;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using TrainworksReloaded.Base.Extensions;
+using TrainworksReloaded.Base.Localization;
+using TrainworksReloaded.Core.Extensions;
+using TrainworksReloaded.Core.Impl;
+using TrainworksReloaded.Core.Interfaces;
+using static CharacterChatterData;
+
+namespace TrainworksReloaded.Base.Character
+{
+    public class CharacterChatterPipeline : IDataPipeline<IRegister<CharacterChatterData>, CharacterChatterData>
+    {
+        private readonly PluginAtlas atlas;
+        private readonly IModLogger<CharacterChatterPipeline> logger;
+        private readonly IRegister<LocalizationTerm> termRegister;
+
+        public CharacterChatterPipeline(
+            PluginAtlas atlas,
+            IModLogger<CharacterChatterPipeline> logger,
+            IRegister<LocalizationTerm> termRegister
+        )
+        {
+            this.atlas = atlas;
+            this.logger = logger;
+            this.termRegister = termRegister;
+        }
+
+        public List<IDefinition<CharacterChatterData>> Run(IRegister<CharacterChatterData> service)
+        {
+            var processList = new List<IDefinition<CharacterChatterData>>();
+            foreach (var config in atlas.PluginDefinitions)
+            {
+                processList.AddRange(
+                    LoadChatter(service, config.Key, config.Value.Configuration)
+                );
+            }
+            return processList;
+        }
+
+        /// <summary>
+        /// Loads the Card Definitions in
+        /// </summary>
+        /// <param name="service"></param>
+        /// <param name="key"></param>
+        /// <param name="pluginConfig"></param>
+        /// <returns></returns>
+        private List<CharacterChatterDefinition> LoadChatter(
+            IRegister<CharacterChatterData> service,
+            string key,
+            IConfiguration pluginConfig
+        )
+        {
+            var processList = new List<CharacterChatterDefinition>();
+            foreach (var child in pluginConfig.GetSection("chatter").GetChildren())
+            {
+                var data = LoadChatterConfiguration(service, key, child);
+                if (data != null)
+                {
+                    processList.Add(data);
+                }
+            }
+            return processList;
+        }
+
+        private CharacterChatterDefinition? LoadChatterConfiguration(
+            IRegister<CharacterChatterData> service,
+            string key,
+            IConfiguration configuration
+        )
+        {
+            var id = configuration.GetSection("id").ParseString();
+            if (id == null)
+            {
+                return null;
+            }
+
+            CharacterChatterData data = new();
+            var name = key.GetId(TemplateConstants.Chatter, id);
+            data.name = name;
+
+            int i = 0;
+            List<ChatterExpressionData> addedExpressions = [];
+            foreach (var child in configuration.GetSection("added_expressions").GetChildren())
+            {
+                var term = child.ParseLocalizationTerm();
+                if (term != null)
+                {
+                    term.Key = $"CharacterChatterData_addedExpressions{i}-{name}";
+                    termRegister.Add(term.Key, term);
+                    addedExpressions.Add(new ChatterExpressionData
+                    {
+                        locKey = term.Key,
+                    });
+                }
+                i++;
+            }
+            AccessTools.Field(typeof(CharacterChatterData), "characterAddedExpressions").SetValue(data, addedExpressions);
+
+            i = 0;
+            List<ChatterExpressionData> attackingExpressions = [];
+            foreach (var child in configuration.GetSection("attacking_expressions").GetChildren())
+            {
+                var term = child.ParseLocalizationTerm();
+                if (term != null)
+                {
+                    term.Key = $"CharacterChatterData_attackingExpressions{i}-{name}";
+                    termRegister.Add(term.Key, term);
+                    attackingExpressions.Add(new ChatterExpressionData
+                    {
+                        locKey = term.Key,
+                    });
+                }
+                i++;
+            }
+            AccessTools.Field(typeof(CharacterChatterData), "characterAttackingExpressions").SetValue(data, attackingExpressions);
+
+            i = 0;
+            List<ChatterExpressionData> idleExpressions = [];
+            foreach (var child in configuration.GetSection("idle_expressions").GetChildren())
+            {
+                var term = child.ParseLocalizationTerm();
+                if (term != null)
+                {
+                    term.Key = $"CharacterChatterData_idleExpressions{i}-{name}";
+                    termRegister.Add(term.Key, term);
+                    idleExpressions.Add(new ChatterExpressionData
+                    {
+                        locKey = term.Key,
+                    });
+                }
+                i++;
+            }
+            AccessTools.Field(typeof(CharacterChatterData), "characterIdleExpressions").SetValue(data, idleExpressions);
+
+            i = 0;
+            List<ChatterExpressionData> slayedExpressions = [];
+            foreach (var child in configuration.GetSection("slayed_expressions").GetChildren())
+            {
+                var term = child.ParseLocalizationTerm();
+                if (term != null)
+                {
+                    term.Key = $"CharacterChatterData_slayedExpressions{i}-{name}";
+                    termRegister.Add(term.Key, term);
+                    slayedExpressions.Add(new ChatterExpressionData
+                    {
+                        locKey = term.Key,
+                    });
+                }
+                i++;
+            }
+            AccessTools.Field(typeof(CharacterChatterData), "characterSlayedExpressions").SetValue(data, slayedExpressions);
+
+            Gender gender = configuration.GetSection("gender").ParseGender(Gender.Neutral);
+            AccessTools.Field(typeof(CharacterChatterData), "gender").SetValue(data, gender);
+
+            service.Register(name, data);
+
+            return new CharacterChatterDefinition(key, data, configuration)
+            {
+                Id = id,
+            };
+        }
+    }
+}

--- a/TrainworksReloaded.Base/Character/CharacterChatterRegister.cs
+++ b/TrainworksReloaded.Base/Character/CharacterChatterRegister.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using HarmonyLib;
+using Malee;
+using TrainworksReloaded.Core.Enum;
+using TrainworksReloaded.Core.Interfaces;
+using UnityEngine;
+
+namespace TrainworksReloaded.Base.Character
+{
+    public class CharacterChatterRegister : Dictionary<string, CharacterChatterData>, IRegister<CharacterChatterData>
+    {
+        private readonly IModLogger<CharacterChatterRegister> logger;
+
+        public CharacterChatterRegister(IModLogger<CharacterChatterRegister> logger)
+        {
+            this.logger = logger;
+        }
+
+
+        public void Register(string key, CharacterChatterData item)
+        {
+            logger.Log(Core.Interfaces.LogLevel.Info, $"Register Character Chatter {key}... ");
+            Add(key, item);
+        }
+        
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
+        {
+            return identifierType switch
+            {
+                RegisterIdentifierType.ReadableID => [.. this.Keys],
+                RegisterIdentifierType.GUID => [.. this.Keys],
+                _ => []
+            };
+        }
+
+        public bool TryLookupIdentifier(string identifier, RegisterIdentifierType identifierType, [NotNullWhen(true)] out CharacterChatterData? lookup, [NotNullWhen(true)] out bool? IsModded)
+        {
+            lookup = default;
+            IsModded = true;
+            switch (identifierType)
+            {
+                case RegisterIdentifierType.ReadableID:
+                    return this.TryGetValue(identifier, out lookup);
+                case RegisterIdentifierType.GUID:
+                    return this.TryGetValue(identifier, out lookup);
+                default:
+                    return false;
+            }
+        }
+
+    }
+}

--- a/TrainworksReloaded.Base/Character/CharacterDataFinalizer.cs
+++ b/TrainworksReloaded.Base/Character/CharacterDataFinalizer.cs
@@ -22,6 +22,7 @@ namespace TrainworksReloaded.Base.Character
         private readonly IRegister<VfxAtLoc> vfxRegister;
         private readonly IRegister<StatusEffectData> statusRegister;
         private readonly IRegister<CardData> cardRegister;
+        private readonly IRegister<CharacterChatterData> chatterRegister;
         private readonly FallbackDataProvider dataProvider;
 
         public CharacterDataFinalizer(
@@ -32,6 +33,7 @@ namespace TrainworksReloaded.Base.Character
             IRegister<VfxAtLoc> vfxRegister,
             IRegister<StatusEffectData> statusRegister,
             IRegister<CardData> cardRegister,
+            IRegister<CharacterChatterData> chatterRegister,
             FallbackDataProvider dataProvider
         )
         {
@@ -42,6 +44,7 @@ namespace TrainworksReloaded.Base.Character
             this.vfxRegister = vfxRegister;
             this.statusRegister = statusRegister;
             this.cardRegister = cardRegister;
+            this.chatterRegister = chatterRegister;
             this.dataProvider = dataProvider;
         }
 
@@ -242,6 +245,16 @@ namespace TrainworksReloaded.Base.Character
             AccessTools
                 .Field(typeof(CharacterData), "startingStatusEffects")
                 .SetValue(data, startingStatusEffects.ToArray());
+
+            // TODO checkOverride is not honored, should allow merging the existing data.
+            var chatterId = configuration.GetSection("chatter").ParseString();
+            if (chatterId != null)
+            {
+                if (chatterRegister.TryLookupId(chatterId.ToId(key, TemplateConstants.Chatter), out var lookup, out var _))
+                {
+                    AccessTools.Field(typeof(CharacterData), "characterChatterData").SetValue(data, lookup);
+                }
+            }
 
             AccessTools
                 .Field(typeof(CharacterData), "fallbackData")

--- a/TrainworksReloaded.Base/Extensions/ParseEnumExtensions.cs
+++ b/TrainworksReloaded.Base/Extensions/ParseEnumExtensions.cs
@@ -956,7 +956,8 @@ namespace TrainworksReloaded.Base.Extensions
                 _ => null
             };
         }
-        public static SpecialCharacterType? ParseSpecialCharacterType(this IConfigurationSection section){
+        public static SpecialCharacterType? ParseSpecialCharacterType(this IConfigurationSection section)
+        {
             var val = section.Value;
             if (string.IsNullOrEmpty(val))
             {
@@ -1036,6 +1037,28 @@ namespace TrainworksReloaded.Base.Extensions
                 result |= classType.Value;
             }
             return result;
+        }
+
+        public static CharacterChatterData.Gender ParseGender(this IConfigurationSection section, CharacterChatterData.Gender defaultValue)
+        {
+            var val = section.Value;
+            if (string.IsNullOrEmpty(val))
+            {
+                return defaultValue;
+            }
+            val = val.ToLower();
+            CharacterChatterData.Gender? value = val switch
+            {
+                "male" => CharacterChatterData.Gender.Male,
+                "female" => CharacterChatterData.Gender.Female,
+                "neutral" => CharacterChatterData.Gender.Neutral,
+                _ => null
+            };
+            if (value == null)
+            {
+                return defaultValue;
+            }
+            return value.Value;
         }
     }
 }

--- a/TrainworksReloaded.Base/TemplateConstants.cs
+++ b/TrainworksReloaded.Base/TemplateConstants.cs
@@ -27,5 +27,6 @@ namespace TrainworksReloaded.Base
         public const string RelicData = "RelicData";
         public const string RelicEffectData = "RelicEffectData";
         public const string Character = "Character";
+        public const string Chatter = "Chatter";
     }
 }

--- a/TrainworksReloaded.Plugin/RailheadPlugin.cs
+++ b/TrainworksReloaded.Plugin/RailheadPlugin.cs
@@ -131,6 +131,7 @@ namespace TrainworksReloaded.Plugin
                         typeof(CardPoolFinalizer),
                         typeof(CharacterTriggerTypeFinalizer),
                         typeof(CardTriggerTypeFinalizer),
+                        typeof(CharacterChatterFinalizer),
                         typeof(RelicDataFinalizer),
                         typeof(RelicEffectDataFinalizer),
                         typeof(GameObjectFinalizer),
@@ -390,6 +391,21 @@ namespace TrainworksReloaded.Plugin
                 {
                     var pipeline = c.GetInstance<
                         IDataPipeline<IRegister<CharacterTriggerData>, CharacterTriggerData>
+                    >();
+                    pipeline.Run(x);
+                });
+
+                //Register Character Chatter
+                c.RegisterSingleton<IRegister<CharacterChatterData>, CharacterChatterRegister>(); 
+                c.RegisterSingleton<CharacterChatterRegister, CharacterChatterRegister>();
+                c.Register<
+                    IDataPipeline<IRegister<CharacterChatterData>, CharacterChatterData>,
+                    CharacterChatterPipeline
+                >();
+                c.RegisterInitializer<IRegister<CharacterChatterData>>(x =>
+                {
+                    var pipeline = c.GetInstance<
+                        IDataPipeline<IRegister<CharacterChatterData>, CharacterChatterData>
                     >();
                     pipeline.Run(x);
                 });

--- a/schemas/base.json
+++ b/schemas/base.json
@@ -32,6 +32,9 @@
         "characters": {
             "$ref": "schemas/characters.json#/properties/characters"
         },
+        "chatter": {
+            "$ref": "schemas/chatter.json#/properties/chatter"
+        },
         "classes": {
             "$ref": "schemas/classes.json#/properties/classes"
         },

--- a/schemas/schemas/characters.json
+++ b/schemas/schemas/characters.json
@@ -104,10 +104,6 @@
                         "type": "string",
                         "description": "Reference to the character's art asset."
                     },
-                    "character_chatter_data": {
-                        "type": "string",
-                        "description": "Reference to the character's dialogue data."
-                    },
                     "character_lore_tooltips": {
                         "type": "array",
                         "description": "List of lore tooltips for this character.",
@@ -118,6 +114,10 @@
                     "character_sound_data": {
                         "type": "string",
                         "description": "Reference to the character's sound data."
+                    },
+                    "chatter": {
+                        "type": "string",
+                        "description": "Reference to the character's dialogue data."
                     },
                     "chosen_variant": {
                         "type": "boolean",

--- a/schemas/schemas/chatter.json
+++ b/schemas/schemas/chatter.json
@@ -1,0 +1,69 @@
+{
+    "$id": "https://raw.githubusercontent.com/Monster-Train-2-Modding-Group/Trainworks-Reloaded/refs/heads/main/schemas/schemas/chatter.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "added_expressions": {
+        "type": "array",
+        "items": {
+          "$ref": "../definitions/parse_term.json"
+        },
+        "description": "Chatter when the character is spawned."
+      },
+      "base_chatter": {
+        "type": "string",
+        "description": "Reference to chatter to use as a base useful for common expressions. Note this is not recursive, that is, the base chatter referenced can't itself set this property."
+      },
+      "attacking_expressions": {
+        "type": "array",
+        "items": {
+          "$ref": "parse_term.json"
+        },
+        "description": "Chatter when the character is attacking."
+      },
+      "gender": {
+        "type": "string",
+        "enum": [
+          "neutral",
+          "male",
+          "female"
+        ],
+        "description": "Gender."
+      },
+      "id": {
+        "type": "string",
+        "description": "Unique identifier for this chatter."
+      },
+      "idle_expressions": {
+        "type": "array",
+        "items": {
+          "$ref": "parse_term.json"
+        },
+        "description": "Chatter when the character is idle."
+      },
+      "slayed_expressions": {
+        "type": "array",
+        "items": {
+          "$ref": "parse_term.json"
+        },
+        "description": "Chatter when the character is slain."
+      },
+      "trigger_expressions": {
+        "type": "array",
+        "description": "Chatter when the character fires a trigger",
+        "items": {
+          "type": "object",
+          "properties": {
+            "trigger": {
+              "$ref": "character_trigger.json",
+              "description": "Trigger type"
+            },
+            "expressions": {
+              "$ref": "parse_term.json"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
CharacterChatterData implementation.

## Test JSON
```
  "chatter": [
    {
      "id": "AlbertChatter",
      "gender": "male",
      "added_expressions": [
        {
          "english": "Albert at your service!"
        }
      ],
      "idle_expressions": [
        {
          "english": "Protect. The. Train."
        }
      ]
    }
  ]
  ```

## Checklist
- [x] `characters.character_chatter_data` renamed -> `characters.chatter`
- [x] `chatter` added.

## Related Issues
#14. Doesn't close it since this PR doesn't handle merging with the existing CharacterChatterData object.
