### PR TITLE
Fix runtime errors due to the new MT2 demo.

### DIFF
--- a/TrainworksReloaded.Base/Character/CharacterDataPipeline.cs
+++ b/TrainworksReloaded.Base/Character/CharacterDataPipeline.cs
@@ -239,20 +239,6 @@ namespace TrainworksReloaded.Base.Character
                     configuration.GetSection("chosen_variant").ParseBool() ?? chosenVariant
                 );
 
-            var removeTriggersOnRelentlessChange =
-                checkOverride
-                && (bool)
-                    AccessTools
-                        .Field(typeof(CharacterData), "removeTriggersOnRelentlessChange")
-                        .GetValue(data);
-            AccessTools
-                .Field(typeof(CharacterData), "removeTriggersOnRelentlessChange")
-                .SetValue(
-                    data,
-                    configuration.GetSection("remove_triggers_on_relentless").ParseBool()
-                        ?? removeTriggersOnRelentlessChange
-                );
-
             var isPyreHeart =
                 checkOverride
                 && (bool)AccessTools.Field(typeof(CharacterData), "isPyreHeart").GetValue(data);
@@ -272,20 +258,6 @@ namespace TrainworksReloaded.Base.Character
                     data,
                     configuration.GetSection("disable_in_daily_challenges").ParseBool()
                         ?? disableInDailyChallenges
-                );
-
-            var canOnlyEquipGraftedEquipment =
-                checkOverride
-                && (bool)
-                    AccessTools
-                        .Field(typeof(CharacterData), "canOnlyEquipGraftedEquipment")
-                        .GetValue(data);
-            AccessTools
-                .Field(typeof(CharacterData), "canOnlyEquipGraftedEquipment")
-                .SetValue(
-                    data,
-                    configuration.GetSection("can_equip_only_grafted").ParseBool()
-                        ?? canOnlyEquipGraftedEquipment
                 );
 
             //int

--- a/TrainworksReloaded.Base/Effect/CardEffectDataPipeline.cs
+++ b/TrainworksReloaded.Base/Effect/CardEffectDataPipeline.cs
@@ -186,15 +186,6 @@ namespace TrainworksReloaded.Base.Effect
                         ?? shouldFailToCastIfTestFails
                 );
 
-            var shouldSkipSubsequentEffectsPreviews = false;
-            AccessTools
-                .Field(typeof(CardEffectData), "shouldSkipSubsequentEffectsPreviews")
-                .SetValue(
-                    data,
-                    configuration.GetSection("skip_subsequent_previews").ParseBool()
-                        ?? shouldSkipSubsequentEffectsPreviews
-                );
-
             var useIntRange = false;
             AccessTools
                 .Field(typeof(CardEffectData), "useIntRange")

--- a/schemas/schemas/characters.json
+++ b/schemas/schemas/characters.json
@@ -96,10 +96,6 @@
                         "type": "boolean",
                         "description": "Whether this character can receive healing."
                     },
-                    "can_equip_only_grafted": {
-                        "type": "boolean",
-                        "description": "Whether this character can only equip grafted equipment."
-                    },
                     "character_art": {
                         "type": "string",
                         "description": "Reference to the character's art asset."
@@ -212,10 +208,6 @@
                     "pyre_heart_data": {
                         "type": "string",
                         "description": "Reference to the Pyre heart data."
-                    },
-                    "remove_triggers_on_relentless": {
-                        "type": "boolean",
-                        "description": "Whether to remove triggers when this character becomes relentless."
                     },
                     "room_modifiers": {
                         "type": "array",

--- a/schemas/schemas/effects.json
+++ b/schemas/schemas/effects.json
@@ -119,10 +119,6 @@
                         "type": "boolean",
                         "description": "Whether to show a notification in the Pyre UI."
                     },
-                    "skip_subsequent_previews": {
-                        "type": "boolean",
-                        "description": "Whether to skip previewing subsequent effects."
-                    },
                     "status_effect_filters": {
                         "type": "array",
                         "description": "List of status effects to filter by.",


### PR DESCRIPTION
## Summary
Removes fields from classes that have been removed.

## Checklist
- [x] effects.skip_subsequent_previews
- [x] characters.remove_triggers_on_relentless
- [x] characters.can_only_equip_grafted  

