### PR TITLE
Fix bug introduced by Custom Subtypes.

### DIFF
--- a/TrainworksReloaded.Base/Character/CharacterDataFinalizer.cs
+++ b/TrainworksReloaded.Base/Character/CharacterDataFinalizer.cs
@@ -276,8 +276,6 @@ namespace TrainworksReloaded.Base.Character
             var subtypes =
                 (List<string>)
                     AccessTools.Field(typeof(CharacterData), "subtypeKeys").GetValue(data) ?? [];
-            //Ensure subtypeKeys List is initialized (shouldn't change the reference) unless it was null previously
-            AccessTools.Field(typeof(CharacterData), "subtypeKeys").SetValue(data, subtypes);
 
             if (checkOverride)
             {
@@ -296,6 +294,7 @@ namespace TrainworksReloaded.Base.Character
                 }
                 subtypes.Add(lookup.Key);
             }
+            AccessTools.Field(typeof(CharacterData), "subtypeKeys").SetValue(data, subtypes);
 
             var roomModifiers = new List<RoomModifierData>();
             if (!checkOverride)

--- a/TrainworksReloaded.Base/Subtype/SubtypeDataRegister.cs
+++ b/TrainworksReloaded.Base/Subtype/SubtypeDataRegister.cs
@@ -40,27 +40,23 @@ namespace TrainworksReloaded.Base.Subtype
 
         public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
         {
-            return identifierType switch
-            {
-                RegisterIdentifierType.ReadableID => [.. this.Keys],
-                RegisterIdentifierType.GUID => [.. this.Keys],
-                _ => []
-            };
+            List<string> ret = [.. this.Keys];
+            if (identifierType == RegisterIdentifierType.GUID)
+                ret.AddRange([.. SubtypeManager.AllData.Select(subtype => subtype.Key)]);
+            return ret;
         }
 
         public bool TryLookupIdentifier(string identifier, RegisterIdentifierType identifierType, [NotNullWhen(true)] out SubtypeData? lookup, [NotNullWhen(true)] out bool? IsModded)
         {
             lookup = default;
             IsModded = true;
-            switch (identifierType)
+            if (this.TryGetValue(identifier, out lookup))
             {
-                case RegisterIdentifierType.ReadableID:
-                    return this.TryGetValue(identifier, out lookup);
-                case RegisterIdentifierType.GUID:
-                    return this.TryGetValue(identifier, out lookup);
-                default:
-                    return false;
+                return true;
             }
+            lookup = SubtypeManager.GetSubtypeData(identifier);
+            IsModded = false;
+            return lookup != null;
         }
     }
 }


### PR DESCRIPTION
## Summary
The register needed a way to grab the Vanilla Subtypes after the replacement. Broke Champions and everything else using vanilla subtypes.