### PR TITLE
EnhancerPools and RelicPools and updates from 05/05 demo update

### DIFF
--- a/TrainworksReloaded.Base/Card/CardPoolFinalizer.cs
+++ b/TrainworksReloaded.Base/Card/CardPoolFinalizer.cs
@@ -13,12 +13,12 @@ namespace TrainworksReloaded.Base.Card
 {
     public class CardPoolFinalizer : IDataFinalizer
     {
-        private readonly IModLogger<CardDataFinalizer> logger;
+        private readonly IModLogger<CardPoolFinalizer> logger;
         private readonly ICache<IDefinition<CardPool>> cache;
         private readonly IRegister<CardData> cardRegister;
 
         public CardPoolFinalizer(
-            IModLogger<CardDataFinalizer> logger,
+            IModLogger<CardPoolFinalizer> logger,
             ICache<IDefinition<CardPool>> cache,
             IRegister<CardData> cardRegister
         )

--- a/TrainworksReloaded.Base/CardUpgrade/CardUpgradePipeline.cs
+++ b/TrainworksReloaded.Base/CardUpgrade/CardUpgradePipeline.cs
@@ -295,6 +295,16 @@ namespace TrainworksReloaded.Base.CardUpgrade
                     configuration.GetSection("bonus_equipment").ParseInt() ?? bonusEquipment
                 );
 
+            var excludeFromClones = checkOverride
+                ? (bool)AccessTools.Field(typeof(CardUpgradeData), "excludeFromClones").GetValue(data)
+                : false;
+            AccessTools
+                .Field(typeof(CardUpgradeData), "excludeFromClones")
+                .SetValue(
+                    data,
+                    configuration.GetSection("exclude_from_clones").ParseBool() ?? excludeFromClones
+                );
+
             //List<String>
             var removeTraitUpgrades =
                 (List<string>)

--- a/TrainworksReloaded.Base/Character/CharacterDataPipeline.cs
+++ b/TrainworksReloaded.Base/Character/CharacterDataPipeline.cs
@@ -374,6 +374,16 @@ namespace TrainworksReloaded.Base.Character
             }
             AccessTools.Field(typeof(CharacterData), "characterLoreTooltipKeys").SetValue(data, tooltips);
 
+            var artistAttribution = checkOverride
+                ? (string)AccessTools.Field(typeof(CharacterData), "artistAttribution").GetValue(data)
+                : "";
+            AccessTools
+                .Field(typeof(CharacterData), "artistAttribution")
+                .SetValue(
+                    data,
+                    configuration.GetSection("artist").ParseString() ?? artistAttribution
+                );
+
             //endless baseline stats
             var endlessBaselineStats = checkOverride
                 ? (EndlessBaselineStats)

--- a/TrainworksReloaded.Base/Class/ClassDataFinalizer.cs
+++ b/TrainworksReloaded.Base/Class/ClassDataFinalizer.cs
@@ -17,20 +17,22 @@ namespace TrainworksReloaded.Base.Class
 {
     public class ClassDataFinalizer : IDataFinalizer
     {
-        private readonly IModLogger<CardDataFinalizer> logger;
+        private readonly IModLogger<ClassDataFinalizer> logger;
         private readonly ICache<IDefinition<ClassData>> cache;
         private readonly IRegister<Sprite> spriteRegister;
         private readonly IRegister<CardData> cardDataRegister;
         private readonly IRegister<RelicData> relicDataRegister;
         private readonly IRegister<CardUpgradeData> upgradeDataRegister;
+        private readonly IRegister<EnhancerPool> enhancerPoolRegister;
 
         public ClassDataFinalizer(
-            IModLogger<CardDataFinalizer> logger,
+            IModLogger<ClassDataFinalizer> logger,
             ICache<IDefinition<ClassData>> cache,
             IRegister<Sprite> spriteRegister,
             IRegister<CardData> cardDataRegister,
             IRegister<RelicData> relicDataRegister,
-            IRegister<CardUpgradeData> upgradeDataRegister
+            IRegister<CardUpgradeData> upgradeDataRegister,
+            IRegister<EnhancerPool> enhancerPoolRegister
         )
         {
             this.logger = logger;
@@ -39,6 +41,7 @@ namespace TrainworksReloaded.Base.Class
             this.cardDataRegister = cardDataRegister;
             this.relicDataRegister = relicDataRegister;
             this.upgradeDataRegister = upgradeDataRegister;
+            this.enhancerPoolRegister = enhancerPoolRegister;
         }
 
         public void FinalizeData()
@@ -159,6 +162,23 @@ namespace TrainworksReloaded.Base.Class
                 AccessTools
                     .Field(typeof(ClassData), "starterCardUpgrade")
                     .SetValue(data, upgradeData);
+            }
+
+            var enhancerPoolId = configuration.GetSection("random_draft_enhancer_pool")?.ParseString();
+            if (enhancerPoolId != null)
+            {
+                if (
+                    enhancerPoolRegister.TryLookupId(
+                        enhancerPoolId.ToId(key, TemplateConstants.EnhancerPool),
+                        out var enhancerPool,
+                        out var _
+                    )
+                )
+                {
+                    AccessTools
+                        .Field(typeof(ClassData), "randomDraftEnhancerPool")
+                        .SetValue(data, enhancerPool);
+                }
             }
 
             //handle champion data

--- a/TrainworksReloaded.Base/Effect/CardEffectDataPipeline.cs
+++ b/TrainworksReloaded.Base/Effect/CardEffectDataPipeline.cs
@@ -230,6 +230,15 @@ namespace TrainworksReloaded.Base.Effect
                         ?? useMagicPowerMultiplier
                 );
 
+            var disallowStatusEffectStackModifiers = false;
+            AccessTools
+                .Field(typeof(CardEffectData), "disallowStatusEffectStackModifiers")
+                .SetValue(
+                    data,
+                    configuration.GetSection("disallow_status_effect_modifiers").ParseBool()
+                        ?? disallowStatusEffectStackModifiers
+                );
+
             //ints
             var paramInt = 0;
             AccessTools

--- a/TrainworksReloaded.Base/Effect/CardEffectFinalizer.cs
+++ b/TrainworksReloaded.Base/Effect/CardEffectFinalizer.cs
@@ -241,6 +241,16 @@ namespace TrainworksReloaded.Base.Effect
                 AccessTools.Field(typeof(CardEffectData), "paramCardFilter").SetValue(data, lookup);
             }
 
+            var filter2Id = configuration.GetSection("param_card_filter_2")?.ParseString();
+            if (filter2Id != null)
+            {
+                upgradeMaskRegister.TryLookupId(
+                    filter2Id.ToId(key, TemplateConstants.UpgradeMask),
+                    out var lookup,
+                    out var _);
+                AccessTools.Field(typeof(CardEffectData), "paramCardFilterSecondary").SetValue(data, lookup);
+            }
+
             var cardPoolId = configuration.GetSection("param_card_pool")?.ParseString();
             if (cardPoolId != null)
             {

--- a/TrainworksReloaded.Base/Relic/CollectableRelicDataPipelineDecorator.cs
+++ b/TrainworksReloaded.Base/Relic/CollectableRelicDataPipelineDecorator.cs
@@ -89,11 +89,12 @@ namespace TrainworksReloaded.Base.Relic
             // Handle force update count label flag
             var forceUpdateCountLabel = configuration.GetSection("force_update_count_label").ParseBool() ?? false;
             AccessTools.Field(typeof(CollectableRelicData), "forceUpdateCountLabel").SetValue(collectableRelic, forceUpdateCountLabel);
-      
             // Handle pool
+            // TODO remove in favor of pools.
             var pool = configuration.GetSection("pool").ParseString();
             if (pool != null)
             {
+                logger.Log(LogLevel.Error, "[Deprecation] relics.pool is deprecated and will be removed soon use relics.pools instead.");
                 if (!relicPoolDelegator.RelicPoolToData.ContainsKey(pool))
                 {
                     relicPoolDelegator.RelicPoolToData[pool] = [];

--- a/TrainworksReloaded.Base/Relic/EnhancerPoolDefinition.cs
+++ b/TrainworksReloaded.Base/Relic/EnhancerPoolDefinition.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using TrainworksReloaded.Core.Interfaces;
+
+namespace TrainworksReloaded.Base.Relic
+{
+    public class EnhancerPoolDefinition(string key, EnhancerPool data, IConfiguration configuration)
+        : IDefinition<EnhancerPool>
+    {
+        public string Id { get; set; } = "";
+        public string Key { get; set; } = key;
+        public EnhancerPool Data { get; set; } = data;
+        public IConfiguration Configuration { get; set; } = configuration;
+        public bool IsModded => true;
+    }
+}

--- a/TrainworksReloaded.Base/Relic/EnhancerPoolFinalizer.cs
+++ b/TrainworksReloaded.Base/Relic/EnhancerPoolFinalizer.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using HarmonyLib;
+using Malee;
+using TrainworksReloaded.Base.Extensions;
+using TrainworksReloaded.Core.Extensions;
+using TrainworksReloaded.Core.Interfaces;
+using UnityEngine.UIElements;
+
+namespace TrainworksReloaded.Base.Relic
+{
+    public class EnhancerPoolFinalizer : IDataFinalizer
+    {
+        private readonly IModLogger<EnhancerPoolFinalizer> logger;
+        private readonly ICache<IDefinition<EnhancerPool>> cache;
+        private readonly IRegister<RelicData> relicRegister;
+
+        public EnhancerPoolFinalizer(
+            IModLogger<EnhancerPoolFinalizer> logger,
+            ICache<IDefinition<EnhancerPool>> cache,
+            IRegister<RelicData> relicRegister
+        )
+        {
+            this.logger = logger;
+            this.cache = cache;
+            this.relicRegister = relicRegister;
+        }
+
+        public void FinalizeData()
+        {
+            foreach (var definition in cache.GetCacheItems())
+            {
+                FinalizePoolData(definition);
+            }
+            cache.Clear();
+        }
+
+        private void FinalizePoolData(IDefinition<EnhancerPool> definition)
+        {
+            var configuration = definition.Configuration;
+            var data = definition.Data;
+            var key = definition.Key;
+
+            logger.Log(Core.Interfaces.LogLevel.Info, $"Finalizing Enhancer Pool {data.name}... ");
+
+            var enhancerDatas = new List<EnhancerData>();
+            var enhancerDatasConfig = configuration.GetSection("enhancers").GetChildren();
+            foreach (var configData in enhancerDatasConfig)
+            {
+                if (configData == null)
+                {
+                    continue;
+                }
+                var idConfig = configData.ParseString();
+                if (idConfig == null)
+                {
+                    continue;
+                }
+
+                var id = idConfig.ToId(key, TemplateConstants.RelicData);
+                if (relicRegister.TryLookupName(id, out var relic, out var _))
+                {
+                    if (relic is EnhancerData enhancer)
+                    {
+                        enhancerDatas.Add(enhancer);
+                    }
+                    else
+                    {
+                        logger.Log(LogLevel.Warning, $"RelicData {id} attempted to be added to EnhancerPool {data.name} but it is not a EnhancerData. Ignoring...");
+                    }
+                }
+            }
+            if (enhancerDatas.Count != 0)
+            {
+                var enhancerDataList =
+                    (ReorderableArray<EnhancerData>)
+                        AccessTools.Field(typeof(EnhancerPool), "relicDataList").GetValue(data);
+                enhancerDataList.Clear();
+                foreach (var item in enhancerDatas)
+                {
+                    enhancerDataList.Add(item);
+                }
+                AccessTools.Field(typeof(EnhancerPool), "relicDataList").SetValue(data, enhancerDataList);
+            }
+        }
+    }
+}

--- a/TrainworksReloaded.Base/Relic/EnhancerPoolPipeline.cs
+++ b/TrainworksReloaded.Base/Relic/EnhancerPoolPipeline.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using TrainworksReloaded.Base.Extensions;
+using TrainworksReloaded.Base.Localization;
+using TrainworksReloaded.Core.Extensions;
+using TrainworksReloaded.Core.Impl;
+using TrainworksReloaded.Core.Interfaces;
+
+namespace TrainworksReloaded.Base.Relic
+{
+    public class EnhancerPoolPipeline : IDataPipeline<IRegister<EnhancerPool>, EnhancerPool>
+    {
+        private readonly PluginAtlas atlas;
+        private readonly IInstanceGenerator<EnhancerPool> generator;
+
+        public EnhancerPoolPipeline(
+            PluginAtlas atlas,
+            IInstanceGenerator<EnhancerPool> generator
+        )
+        {
+            this.atlas = atlas;
+            this.generator = generator;
+        }
+
+        public List<IDefinition<EnhancerPool>> Run(IRegister<EnhancerPool> service)
+        {
+            var processList = new List<IDefinition<EnhancerPool>>();
+            foreach (var config in atlas.PluginDefinitions)
+            {
+                processList.AddRange(LoadPools(service, config.Key, config.Value.Configuration));
+            }
+            return processList;
+        }
+
+        public List<EnhancerPoolDefinition> LoadPools(
+            IRegister<EnhancerPool> service,
+            string key,
+            IConfiguration pluginConfig
+        )
+        {
+            var processList = new List<EnhancerPoolDefinition>();
+            foreach (var child in pluginConfig.GetSection("enhancer_pools").GetChildren())
+            {
+                var data = LoadEnhancerPoolConfiguration(service, key, child);
+                if (data != null)
+                {
+                    processList.Add(data);
+                }
+            }
+            return processList;
+        }
+
+        public EnhancerPoolDefinition? LoadEnhancerPoolConfiguration(
+            IRegister<EnhancerPool> service,
+            string key,
+            IConfiguration configuration
+        )
+        {
+            var id = configuration.GetSection("id").ParseString();
+            if (id == null)
+            {
+                return null;
+            }
+
+            var name = key.GetId(TemplateConstants.EnhancerPool, id);
+            var data = generator.CreateInstance();
+            data.name = name;
+            service.Register(name, data);
+
+            return new EnhancerPoolDefinition(key, data, configuration) { Id = id };
+        }
+    }
+}

--- a/TrainworksReloaded.Base/Relic/EnhancerPoolRegister.cs
+++ b/TrainworksReloaded.Base/Relic/EnhancerPoolRegister.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using TrainworksReloaded.Base.CardUpgrade;
+using TrainworksReloaded.Core.Interfaces;
+using TrainworksReloaded.Core.Enum;
+using HarmonyLib;
+
+namespace TrainworksReloaded.Base.Relic
+{
+    public class EnhancerPoolRegister : Dictionary<string, EnhancerPool>, IRegister<EnhancerPool>
+    {
+        private readonly IModLogger<EnhancerPoolRegister> logger;
+        private readonly Lazy<SaveManager> SaveManager;
+
+        public EnhancerPoolRegister(GameDataClient client, IModLogger<EnhancerPoolRegister> logger)
+        {
+            SaveManager = new Lazy<SaveManager>(() =>
+            {
+                if (client.TryGetProvider<SaveManager>(out var provider))
+                {
+                    return provider;
+                }
+                else
+                {
+                    return new SaveManager();
+                }
+            });
+            this.logger = logger;
+        }
+
+        public void Register(string key, EnhancerPool item)
+        {
+            logger.Log(Core.Interfaces.LogLevel.Info, $"Register Enhancer Pool {key}... ");
+            Add(key, item);
+        }
+
+
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
+        {
+            return [.. this.Keys];
+        }
+
+        public bool TryLookupIdentifier(
+            string identifier,
+            RegisterIdentifierType identifierType,
+            [NotNullWhen(true)] out EnhancerPool? lookup,
+            [NotNullWhen(true)] out bool? IsModded
+        )
+        {
+
+            if (this.TryGetValue(identifier, out lookup))
+            {
+                IsModded = true;
+                return true;
+            }
+            else
+            {
+                lookup = GetVanillaEnhancerPool(SaveManager.Value.GetAllGameData(), identifier);
+                IsModded = false;
+                return lookup != null;
+            }
+        }
+
+        public static EnhancerPool? GetVanillaEnhancerPool(AllGameData allGameData, string poolName)
+        {
+            var merchantPoolName = poolName switch
+            {
+                "unit_upgrade_common" => "UnitUpgradePoolCommon",
+                "unit_upgrade_rare" => "UnitUpgradePoolRare",
+                "spell_upgrade_common" => "SpellUpgradePoolCommon",
+                "spell_upgrade_cost_reduction" => "SpellUpgradePoolCostReduction",
+                "spell_upgrade_rare" => "SpellUpgradePoolRare",
+                _ => null
+            };
+
+            if (poolName == "draft_upgrade")
+            {
+                CollectableRelicData? capriciousReflection = allGameData.FindCollectableRelicData("9e0e5d4e-6d16-43f1-8cd4-cc4c2b431afd");
+                var effect = capriciousReflection?.GetFirstRelicEffectData<RelicEffectAddStartingUpgradeToCardDrafts>();
+                return effect?.GetParamEnhancerPool();
+            }
+            else if (merchantPoolName != null)
+            {
+                IReadOnlyList<string> Merchants = [
+                    "ed1b1cfa-9da2-4588-85fe-6360913ef41e", // Unit Upgrades
+                    "9a70610f-8900-4900-b96d-4f88faa0f105", // Spell Upgrades
+                    "f57bc1e9-4e86-4abf-af2a-0d56d2b3f59a", // Artifact Merchant
+                    "e2c67b52-4d52-48b5-b20a-c6f4c12e44fa"  // Equipment Merchant
+                ];
+                foreach (var merchantID in Merchants)
+                {
+                    var mapNode = allGameData.FindMapNodeData(merchantID);
+                    if (mapNode is MerchantData merchant)
+                    {
+                        for (int i = 0; i < merchant.GetNumRewards(); i++)
+                        {
+                            RewardData reward = merchant.GetReward(i).RewardData;
+                            if (reward is EnhancerPoolRewardData enhancerPoolReward)
+                            {
+                                var foundEnhancerPool = (EnhancerPool)AccessTools.Field(typeof(EnhancerPoolRewardData), "relicPool").GetValue(enhancerPoolReward);
+                                if (foundEnhancerPool.name == merchantPoolName)
+                                {
+                                    return foundEnhancerPool;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/TrainworksReloaded.Base/Relic/PoolingRelicDataPipelineDecorator.cs
+++ b/TrainworksReloaded.Base/Relic/PoolingRelicDataPipelineDecorator.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using TrainworksReloaded.Core.Interfaces;
+
+namespace TrainworksReloaded.Base.Relic
+{
+    public class PoolingRelicDataPipelineDecorator : IDataPipeline<IRegister<RelicData>, RelicData>
+    {
+        private readonly IDataPipeline<IRegister<RelicData>, RelicData> decoratee;
+        private readonly VanillaRelicPoolDelegator collectableDelegator;
+        private readonly VanillaEnhancerPoolDelegator enhancerDelegator;
+
+        public PoolingRelicDataPipelineDecorator(
+            IDataPipeline<IRegister<RelicData>, RelicData> decoratee,
+            VanillaRelicPoolDelegator collectableDelegator,
+            VanillaEnhancerPoolDelegator enhancerDelegator
+        )
+        {
+            this.decoratee = decoratee;
+            this.collectableDelegator = collectableDelegator;
+            this.enhancerDelegator = enhancerDelegator;
+        }
+
+        public List<IDefinition<RelicData>> Run(IRegister<RelicData> service)
+        {
+            var definitions = decoratee.Run(service);
+            foreach (var definition in definitions)
+            {
+                var data = definition.Data;
+                var pools = definition
+                    .Configuration.GetSection("pools")
+                    .GetChildren()
+                    .Where(xs => xs.Value != null)
+                    .Select(xs => xs.Value!)
+                    .ToList()!;
+                if (data is CollectableRelicData collectableRelicData)
+                {
+                    foreach (var pool in pools)
+                    {
+                        if (collectableDelegator.RelicPoolToData.ContainsKey(pool))
+                        {
+                            collectableDelegator.RelicPoolToData[pool].Add(collectableRelicData);
+                        }
+                        else
+                        {
+                            collectableDelegator.RelicPoolToData.Add(pool, [collectableRelicData]);
+                        }
+                    }
+                }
+                else if (data is EnhancerData enhancerData)
+                {
+                    foreach (var pool in pools)
+                    {
+                        if (enhancerDelegator.EnhancerPoolToData.ContainsKey(pool))
+                        {
+                            enhancerDelegator.EnhancerPoolToData[pool].Add(enhancerData);
+                        }
+                        else
+                        {
+                            enhancerDelegator.EnhancerPoolToData.Add(pool, [enhancerData]);
+                        }
+                    }
+                }
+
+            }
+            return definitions;
+        }
+    }
+}

--- a/TrainworksReloaded.Base/Relic/RelicEffectDataFinalizer.cs
+++ b/TrainworksReloaded.Base/Relic/RelicEffectDataFinalizer.cs
@@ -26,6 +26,7 @@ namespace TrainworksReloaded.Base.Relic
         private readonly IRegister<VfxAtLoc> vfxRegister;
         private readonly IRegister<RelicData> relicRegister;
         private readonly IRegister<CharacterTriggerData.Trigger> triggerEnumRegister;
+        private readonly IRegister<EnhancerPool> enhancerPoolRegister;
 
         public RelicEffectDataFinalizer(
             IModLogger<RelicEffectDataFinalizer> logger,
@@ -43,7 +44,8 @@ namespace TrainworksReloaded.Base.Relic
             IRegister<CardUpgradeMaskData> cardUpgradeMaskRegister,
             IRegister<VfxAtLoc> vfxRegister,
             IRegister<RelicData> relicRegister,
-            IRegister<CharacterTriggerData.Trigger> triggerEnumRegister
+            IRegister<CharacterTriggerData.Trigger> triggerEnumRegister,
+            IRegister<EnhancerPool> enhancerPoolRegister
         )
         {
             this.logger = logger;
@@ -62,6 +64,7 @@ namespace TrainworksReloaded.Base.Relic
             this.vfxRegister = vfxRegister;
             this.relicRegister = relicRegister;
             this.triggerEnumRegister = triggerEnumRegister;
+            this.enhancerPoolRegister = enhancerPoolRegister;
         }
 
         public void FinalizeData()
@@ -85,7 +88,6 @@ namespace TrainworksReloaded.Base.Relic
             - CardSetBuilder
             - CollectibleRelicData
             - CovenantData
-            - EnhancerPool
             - RandomChampionPool
             - RoomData
             */ 
@@ -348,6 +350,23 @@ namespace TrainworksReloaded.Base.Relic
             AccessTools
                 .Field(typeof(RelicEffectData), "paramTrigger")
                 .SetValue(data, paramTrigger);
+
+            var enhancerPoolId = configuration.GetSection("param_enhancer_pool")?.ParseString();
+            if (enhancerPoolId != null)
+            {
+                if (
+                    enhancerPoolRegister.TryLookupId(
+                        enhancerPoolId.ToId(key, TemplateConstants.EnhancerPool),
+                        out var enhancerPool,
+                        out var _
+                    )
+                )
+                {
+                    AccessTools
+                        .Field(typeof(RelicEffectData), "paramEnhancerPool")
+                        .SetValue(data, enhancerPool);
+                }
+            }
         }
     }
 }

--- a/TrainworksReloaded.Base/Relic/RelicPoolDefinition.cs
+++ b/TrainworksReloaded.Base/Relic/RelicPoolDefinition.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using TrainworksReloaded.Core.Interfaces;
+
+namespace TrainworksReloaded.Base.Relic
+{
+    public class RelicPoolDefinition(string key, RelicPool data, IConfiguration configuration)
+        : IDefinition<RelicPool>
+    {
+        public string Id { get; set; } = "";
+        public string Key { get; set; } = key;
+        public RelicPool Data { get; set; } = data;
+        public IConfiguration Configuration { get; set; } = configuration;
+        public bool IsModded => true;
+    }
+}

--- a/TrainworksReloaded.Base/Relic/RelicPoolFinalizer.cs
+++ b/TrainworksReloaded.Base/Relic/RelicPoolFinalizer.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using HarmonyLib;
+using Malee;
+using TrainworksReloaded.Base.Extensions;
+using TrainworksReloaded.Core.Extensions;
+using TrainworksReloaded.Core.Interfaces;
+using UnityEngine.UIElements;
+
+namespace TrainworksReloaded.Base.Relic
+{
+    public class RelicPoolFinalizer : IDataFinalizer
+    {
+        private readonly IModLogger<RelicPoolFinalizer> logger;
+        private readonly ICache<IDefinition<RelicPool>> cache;
+        private readonly IRegister<RelicData> relicRegister;
+
+        public RelicPoolFinalizer(
+            IModLogger<RelicPoolFinalizer> logger,
+            ICache<IDefinition<RelicPool>> cache,
+            IRegister<RelicData> relicRegister
+        )
+        {
+            this.logger = logger;
+            this.cache = cache;
+            this.relicRegister = relicRegister;
+        }
+
+        public void FinalizeData()
+        {
+            foreach (var definition in cache.GetCacheItems())
+            {
+                FinalizePoolData(definition);
+            }
+            cache.Clear();
+        }
+
+        private void FinalizePoolData(IDefinition<RelicPool> definition)
+        {
+            var configuration = definition.Configuration;
+            var data = definition.Data;
+            var key = definition.Key;
+
+            logger.Log(Core.Interfaces.LogLevel.Info, $"Finalizing Relic Pool {data.name}... ");
+
+            var relicDatas = new List<CollectableRelicData>();
+            var relicDatasConfig = configuration.GetSection("relics").GetChildren();
+            foreach (var configData in relicDatasConfig)
+            {
+                if (configData == null)
+                {
+                    continue;
+                }
+                var idConfig = configData.ParseString();
+                if (idConfig == null)
+                {
+                    continue;
+                }
+
+                var id = idConfig.ToId(key, TemplateConstants.RelicData);
+                if (relicRegister.TryLookupName(id, out var relic, out var _))
+                {
+                    if (relic is CollectableRelicData collectable)
+                    {
+                        relicDatas.Add(collectable);
+                    }
+                    else
+                    {
+                        logger.Log(LogLevel.Warning, $"RelicData {id} attempted to be added to RelicPool {data.name} but it is not a CollectableRelic. Ignoring...");
+                    }
+                }
+            }
+            if (relicDatas.Count != 0)
+            {
+                var relicDataList =
+                    (ReorderableArray<CollectableRelicData>)
+                        AccessTools.Field(typeof(RelicPool), "relicDataList").GetValue(data);
+                relicDataList.Clear();
+                foreach (var item in relicDatas)
+                {
+                    relicDataList.Add(item);
+                }
+                AccessTools.Field(typeof(RelicPool), "relicDataList").SetValue(data, relicDataList);
+            }
+        }
+    }
+}

--- a/TrainworksReloaded.Base/Relic/RelicPoolPipeline.cs
+++ b/TrainworksReloaded.Base/Relic/RelicPoolPipeline.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using TrainworksReloaded.Base.Extensions;
+using TrainworksReloaded.Base.Localization;
+using TrainworksReloaded.Core.Extensions;
+using TrainworksReloaded.Core.Impl;
+using TrainworksReloaded.Core.Interfaces;
+
+namespace TrainworksReloaded.Base.Relic
+{
+    public class RelicPoolPipeline : IDataPipeline<IRegister<RelicPool>, RelicPool>
+    {
+        private readonly PluginAtlas atlas;
+        private readonly IInstanceGenerator<RelicPool> generator;
+
+        public RelicPoolPipeline(
+            PluginAtlas atlas,
+            IInstanceGenerator<RelicPool> generator
+        )
+        {
+            this.atlas = atlas;
+            this.generator = generator;
+        }
+
+        public List<IDefinition<RelicPool>> Run(IRegister<RelicPool> service)
+        {
+            var processList = new List<IDefinition<RelicPool>>();
+            foreach (var config in atlas.PluginDefinitions)
+            {
+                processList.AddRange(LoadPools(service, config.Key, config.Value.Configuration));
+            }
+            return processList;
+        }
+
+        public List<RelicPoolDefinition> LoadPools(
+            IRegister<RelicPool> service,
+            string key,
+            IConfiguration pluginConfig
+        )
+        {
+            var processList = new List<RelicPoolDefinition>();
+            foreach (var child in pluginConfig.GetSection("relic_pools").GetChildren())
+            {
+                var data = LoadRelicPoolConfiguration(service, key, child);
+                if (data != null)
+                {
+                    processList.Add(data);
+                }
+            }
+            return processList;
+        }
+
+        public RelicPoolDefinition? LoadRelicPoolConfiguration(
+            IRegister<RelicPool> service,
+            string key,
+            IConfiguration configuration
+        )
+        {
+            var id = configuration.GetSection("id").ParseString();
+            if (id == null)
+            {
+                return null;
+            }
+
+            var name = key.GetId(TemplateConstants.RelicPool, id);
+            var data = generator.CreateInstance();
+            data.name = name;
+            service.Register(name, data);
+
+            return new RelicPoolDefinition(key, data, configuration) { Id = id };
+        }
+    }
+}

--- a/TrainworksReloaded.Base/Relic/RelicPoolRegister.cs
+++ b/TrainworksReloaded.Base/Relic/RelicPoolRegister.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using TrainworksReloaded.Base.CardUpgrade;
+using TrainworksReloaded.Core.Interfaces;
+using TrainworksReloaded.Core.Enum;
+
+namespace TrainworksReloaded.Base.Relic
+{
+    public class RelicPoolRegister : Dictionary<string, RelicPool>, IRegister<RelicPool>
+    {
+        private readonly IModLogger<RelicPoolRegister> logger;
+
+        public RelicPoolRegister(GameDataClient client, IModLogger<RelicPoolRegister> logger)
+        {
+            this.logger = logger;
+        }
+
+        public void Register(string key, RelicPool item)
+        {
+            logger.Log(Core.Interfaces.LogLevel.Info, $"Register Relic Pool {key}... ");
+            Add(key, item);
+        }
+
+
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
+        {
+            return [.. this.Keys];
+        }
+
+        public bool TryLookupIdentifier(
+            string identifier,
+            RegisterIdentifierType identifierType,
+            [NotNullWhen(true)] out RelicPool? lookup,
+            [NotNullWhen(true)] out bool? IsModded
+        )
+        {
+            IsModded = true;
+            return this.TryGetValue(identifier, out lookup);
+        }
+    }
+}

--- a/TrainworksReloaded.Base/TemplateConstants.cs
+++ b/TrainworksReloaded.Base/TemplateConstants.cs
@@ -17,6 +17,8 @@ namespace TrainworksReloaded.Base
         public const string CharacterTrigger = "CTrigger";
         public const string RoomModifier = "RoomModifier";
         public const string CardPool = "CardPool";
+        public const string RelicPool = "RelicPool";
+        public const string EnhancerPool = "EnhancerPool";
         public const string RewardData = "RewardData";
         public const string MapNode = "MapNode";
         public const string Sprite = "Sprite";

--- a/TrainworksReloaded.Plugin/Patches/InitializationPatch.cs
+++ b/TrainworksReloaded.Plugin/Patches/InitializationPatch.cs
@@ -78,7 +78,7 @@ namespace TrainworksReloaded.Plugin.Patches
             var enhancerDelegator = container.GetInstance<VanillaEnhancerPoolDelegator>();
             foreach (var poolName in enhancerDelegator.EnhancerPoolToData.Keys)
             {
-                var enhancerPool = GetVanillaEnhancerPool(____assetLoadingData.AllGameData, poolName);
+                var enhancerPool = EnhancerPoolRegister.GetVanillaEnhancerPool(____assetLoadingData.AllGameData, poolName);
                 if (enhancerPool == null)
                 {
                     logger.Log(LogLevel.Warning, $"Could not find enhancer pool associated with {poolName}!");
@@ -184,53 +184,5 @@ namespace TrainworksReloaded.Plugin.Patches
             logger.Log(LogLevel.Info, "TrainworksReloaded initialization complete!");
         }
 
-        private static EnhancerPool? GetVanillaEnhancerPool(AllGameData allGameData, string poolName)
-        {
-            var merchantPoolName = poolName switch
-            {
-                "unit_upgrade_common" => "UnitUpgradePoolCommon",
-                "unit_upgrade_rare" => "UnitUpgradePoolRare",
-                "spell_upgrade_common" => "SpellUpgradePoolCommon",
-                "spell_upgrade_cost_reduction" => "SpellUpgradePoolCostReduction",
-                "spell_upgrade_rare" => "SpellUpgradePoolRare",
-                _ => null
-            };
-
-            if (poolName == "draft_upgrade")
-            {
-                CollectableRelicData? capriciousReflection = allGameData.FindCollectableRelicData("9e0e5d4e-6d16-43f1-8cd4-cc4c2b431afd");
-                var effect = capriciousReflection?.GetFirstRelicEffectData<RelicEffectAddStartingUpgradeToCardDrafts>();
-                return effect?.GetParamEnhancerPool();
-            }
-            else if (merchantPoolName != null)
-            {
-                IReadOnlyList<string> Merchants = [
-                    "ed1b1cfa-9da2-4588-85fe-6360913ef41e", // Unit Upgrades
-                    "9a70610f-8900-4900-b96d-4f88faa0f105", // Spell Upgrades
-                    "f57bc1e9-4e86-4abf-af2a-0d56d2b3f59a", // Artifact Merchant
-                    "e2c67b52-4d52-48b5-b20a-c6f4c12e44fa"  // Equipment Merchant
-                ];
-                foreach (var merchantID in Merchants)
-                {
-                    var mapNode = allGameData.FindMapNodeData(merchantID);
-                    if (mapNode is MerchantData merchant)
-                    {
-                        for (int i = 0; i < merchant.GetNumRewards(); i++)
-                        {
-                            RewardData reward = merchant.GetReward(i).RewardData;
-                            if (reward is EnhancerPoolRewardData enhancerPoolReward)
-                            {
-                                var foundEnhancerPool = (EnhancerPool)AccessTools.Field(typeof(EnhancerPoolRewardData), "relicPool").GetValue(enhancerPoolReward);
-                                if (foundEnhancerPool.name == merchantPoolName)
-                                {
-                                    return foundEnhancerPool;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            return null;
-        }
     }
 }

--- a/TrainworksReloaded.Plugin/RailheadPlugin.cs
+++ b/TrainworksReloaded.Plugin/RailheadPlugin.cs
@@ -130,6 +130,8 @@ namespace TrainworksReloaded.Plugin
                         typeof(MapNodeFinalizer),
                         typeof(RewardDataFinalizer),
                         typeof(CardPoolFinalizer),
+                        typeof(EnhancerPoolFinalizer),
+                        typeof(RelicPoolFinalizer),
                         typeof(CharacterTriggerTypeFinalizer),
                         typeof(CardTriggerTypeFinalizer),
                         typeof(CharacterChatterFinalizer),
@@ -272,7 +274,7 @@ namespace TrainworksReloaded.Plugin
                     pipeline.Run(x);
                 });
 
-                //Register Custom Character Triggers Types.
+                //Register Custom Character Trigger Types.
                 c.RegisterSingleton<
                     IRegister<CharacterTriggerData.Trigger>,
                     CharacterTriggerTypeRegister
@@ -296,7 +298,7 @@ namespace TrainworksReloaded.Plugin
                     pipeline.Run(x);
                 });
 
-                //Register Custom Card Triggers Types.
+                //Register Custom Card Trigger Types.
                 c.RegisterSingleton<IRegister<CardTriggerType>, CardTriggerTypeRegister>();
                 c.RegisterSingleton<CardTriggerTypeRegister, CardTriggerTypeRegister>();
                 c.Register<
@@ -356,13 +358,33 @@ namespace TrainworksReloaded.Plugin
                     PoolingCardDataPipelineDecorator
                 >();
 
-                //register Card Pool
+                //Register Card Pool
                 c.RegisterSingleton<IRegister<CardPool>, CardPoolRegister>(); //a place to register and access custom card data
                 c.RegisterSingleton<CardPoolRegister, CardPoolRegister>();
                 c.Register<IDataPipeline<IRegister<CardPool>, CardPool>, CardPoolPipeline>(); //a data pipeline to run as soon as register is needed
                 c.RegisterInitializer<IRegister<CardPool>>(x =>
                 {
                     var pipeline = c.GetInstance<IDataPipeline<IRegister<CardPool>, CardPool>>();
+                    pipeline.Run(x);
+                });
+
+                //Register Enhancer Pool
+                c.RegisterSingleton<IRegister<EnhancerPool>, EnhancerPoolRegister>();
+                c.RegisterSingleton<EnhancerPoolRegister, EnhancerPoolRegister>();
+                c.Register<IDataPipeline<IRegister<EnhancerPool>, EnhancerPool>, EnhancerPoolPipeline>();
+                c.RegisterInitializer<IRegister<EnhancerPool>>(x =>
+                {
+                    var pipeline = c.GetInstance<IDataPipeline<IRegister<EnhancerPool>, EnhancerPool>>();
+                    pipeline.Run(x);
+                });
+
+                //Register Relic Pool
+                c.RegisterSingleton<IRegister<RelicPool>, RelicPoolRegister>();
+                c.RegisterSingleton<RelicPoolRegister, RelicPoolRegister>();
+                c.Register<IDataPipeline<IRegister<RelicPool>, RelicPool>, RelicPoolPipeline>();
+                c.RegisterInitializer<IRegister<RelicPool>>(x =>
+                {
+                    var pipeline = c.GetInstance<IDataPipeline<IRegister<RelicPool>, RelicPool>>();
                     pipeline.Run(x);
                 });
 
@@ -535,9 +557,13 @@ namespace TrainworksReloaded.Plugin
                     [typeof(CollectableRelicDataFactory), typeof(EnhancerDataFactory)],
                     Lifestyle.Singleton
                 );
+                c.RegisterDecorator<
+                IDataPipeline<IRegister<RelicData>, RelicData>,
+                PoolingRelicDataPipelineDecorator>();
+
 
                 //CollectableRelicData
-                c.RegisterDecorator(
+c.RegisterDecorator(
                     typeof(IDataPipeline<IRegister<RelicData>, RelicData>),
                     typeof(CollectableRelicDataPipelineDecorator)
                 );

--- a/schemas/base.json
+++ b/schemas/base.json
@@ -41,6 +41,9 @@
         "effects": {
             "$ref": "schemas/effects.json#/properties/effects"
         },
+        "enhancer_pools": {
+            "$ref": "schemas/enhancer_pools.json#/properties/enhancer_pools"
+        },
         "game_objects": {
             "$ref": "schemas/game_objects.json#/properties/game_objects"
         },
@@ -50,11 +53,14 @@
         "map_nodes": {
             "$ref": "schemas/map_nodes.json#/properties/map_nodes"
         },
-        "rewards": {
-            "$ref": "schemas/rewards.json#/properties/rewards"
+        "relic_pools": {
+            "$ref": "schemas/relic_pools.json#/properties/relic_pools"
         },
         "replacement_texts": {
             "$ref": "schemas/replacement_texts.json#/properties/replacement_texts"
+        },
+        "rewards": {
+            "$ref": "schemas/rewards.json#/properties/rewards"
         },
         "room_modifiers": {
             "$ref": "schemas/room_modifiers.json#/properties/room_modifiers"

--- a/schemas/schemas/characters.json
+++ b/schemas/schemas/characters.json
@@ -1,288 +1,292 @@
 {
-    "$id": "https://raw.githubusercontent.com/Monster-Train-2-Modding-Group/Trainworks-Reloaded/refs/heads/main/schemas/schemas/characters.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "properties": {
-        "characters": {
+  "$id": "https://raw.githubusercontent.com/Monster-Train-2-Modding-Group/Trainworks-Reloaded/refs/heads/main/schemas/schemas/characters.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "characters": {
+      "type": "array",
+      "uniqueItems": true,
+      "description": "A collection of all characters in the game, defining their properties, abilities, and behaviors.",
+      "items": {
+        "properties": {
+          "ability": {
+            "type": "string",
+            "description": "The unique identifier for this character's ability."
+          },
+          "artist": {
+            "type": "string",
+            "description": "The artist who created the character art."
+          },
+          "animator": {
+            "type": "string",
+            "description": "Reference to the character's animation controller."
+          },
+          "ascends_train_automatically": {
+            "type": "boolean",
+            "description": "Whether this character automatically moves up the train when possible."
+          },
+          "attack_damage": {
+            "type": "integer",
+            "description": "Base damage dealt by this character's attacks."
+          },
+          "attack_teleports_to_defender": {
+            "type": "boolean",
+            "description": "Whether this character teleports to its target when attacking."
+          },
+          "attack_vfx": {
+            "type": "string",
+            "description": "Visual effect played when this character attacks."
+          },
+          "block_size_increase": {
+            "type": "boolean",
+            "description": "Whether this character's size increases when blocking."
+          },
+          "boss_action_groups": {
+            "type": "array",
+            "description": "List of action groups for boss characters.",
+            "items": {
+              "properties": {
+                "repeats": {
+                  "type": "integer",
+                  "description": "Number of times this action group repeats."
+                },
+                "actions": {
+                  "type": "array",
+                  "description": "List of actions in this group.",
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "Name of this action."
+                      },
+                      "tooltip": {
+                        "$ref": "../definitions/parse_term.json",
+                        "description": "Localized text describing this action."
+                      },
+                      "team": {
+                        "$ref": "../definitions/team.json",
+                        "description": "Which team this action affects."
+                      },
+                      "effects": {
+                        "type": "array",
+                        "description": "List of effects this action applies.",
+                        "items": {
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "Reference to an effect's unique identifier."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "boss_cast_vfx": {
+            "type": "string",
+            "description": "Visual effect played when this boss character casts an ability."
+          },
+          "boss_room_cast_vfx": {
+            "type": "string",
+            "description": "Visual effect played in the room when this boss character casts an ability."
+          },
+          "can_attack": {
+            "type": "boolean",
+            "description": "Whether this character can perform attacks."
+          },
+          "can_be_healed": {
+            "type": "boolean",
+            "description": "Whether this character can receive healing."
+          },
+          "character_art": {
+            "type": "string",
+            "description": "Reference to the character's art asset."
+          },
+          "character_lore_tooltips": {
+            "type": "array",
+            "description": "List of lore tooltips for this character.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "character_sound_data": {
+            "type": "string",
+            "description": "Reference to the character's sound data."
+          },
+          "chatter": {
+            "type": "string",
+            "description": "Reference to the character's dialogue data."
+          },
+          "chosen_variant": {
+            "type": "boolean",
+            "description": "Whether this is a chosen variant of the character."
+          },
+          "death_slides_backwards": {
+            "type": "boolean",
+            "description": "Whether this character slides backward when dying."
+          },
+          "death_type": {
+            "$ref": "../definitions/death_type.json",
+            "description": "Type of death animation to play."
+          },
+          "death_vfx": {
+            "type": "string",
+            "description": "Visual effect played when this character dies."
+          },
+          "disable_in_daily_challenges": {
+            "type": "boolean",
+            "description": "Whether this character is disabled in daily challenges."
+          },
+          "endless_stats": {
+            "type": "object",
+            "description": "Stats for this character in endless mode.",
+            "properties": {
+              "health": {
+                "type": "integer",
+                "description": "Health value in endless mode."
+              },
+              "attack": {
+                "type": "integer",
+                "description": "Attack value in endless mode."
+              }
+            },
+            "required": [
+              "health",
+              "attack"
+            ]
+          },
+          "enemy_relic": {
+            "type": "string",
+            "description": "Reference to a relic for the enemy's relic data."
+          },
+          "equip_limit": {
+            "type": "integer",
+            "description": "Maximum number of equipment this character can have."
+          },
+          "grafted_equipment": {
+            "type": "string",
+            "description": "Reference to this character's grafted equipment."
+          },
+          "health": {
+            "type": "integer",
+            "description": "Base health of this character."
+          },
+          "hide_in_logbook": {
+            "type": "boolean",
+            "description": "Whether this character should be hidden in the logbook."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for this character."
+          },
+          "impact_vfx": {
+            "type": "string",
+            "description": "Visual effect played when this character is hit."
+          },
+          "is_mini_boss": {
+            "type": "boolean",
+            "description": "Whether this character is a mini-boss."
+          },
+          "is_outer_train_boss": {
+            "type": "boolean",
+            "description": "Whether this character is an outer train boss."
+          },
+          "is_pyre": {
+            "type": "boolean",
+            "description": "Whether this character is the Pyre."
+          },
+          "loops_between_floors": {
+            "type": "boolean",
+            "description": "Whether this character loops between floors."
+          },
+          "names": {
+            "$ref": "../definitions/parse_term.json",
+            "description": "Localized text for this character's name."
+          },
+          "prevent_abilities_from_equipment": {
+            "type": "boolean",
+            "description": "Prevents ability from being overwritten by equipment"
+          },
+          "projectile_vfx": {
+            "type": "string",
+            "description": "Visual effect played for this character's projectiles."
+          },
+          "pyre_heart_data": {
+            "type": "string",
+            "description": "Reference to the Pyre heart data."
+          },
+          "room_modifiers": {
+            "type": "array",
+            "description": "List of room modifiers this character applies.",
+            "items": {
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Reference to a room modifier's unique identifier."
+                }
+              }
+            }
+          },
+          "size": {
+            "type": "integer",
+            "description": "Size of this character in the room."
+          },
+          "starting_status_effects": {
+            "type": "array",
+            "description": "List of status effects this character starts with.",
+            "items": {
+              "$ref": "../definitions/status_effect.json"
+            }
+          },
+          "status_effect_immunities": {
+            "type": "array",
+            "description": "List of status effects this character is immune to.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "subtypes": {
+            "type": "array",
+            "description": "List of subtypes this character belongs to.",
+            "items": {
+              "$ref": "../definitions/subtype.json"
+            }
+          },
+          "titan_affinity": {
+            "$ref": "../definitions/titan_affinity.json",
+            "description": "This character's affinity with titans."
+          },
+          "triggers": {
             "type": "array",
             "uniqueItems": true,
-            "description": "A collection of all characters in the game, defining their properties, abilities, and behaviors.",
+            "description": "List of triggers this character has.",
             "items": {
-                "properties": {
-                    "ability": {
-                        "type": "string",
-                        "description": "The unique identifier for this character's ability."
-                    },
-                    "animator": {
-                        "type": "string",
-                        "description": "Reference to the character's animation controller."
-                    },
-                    "ascends_train_automatically": {
-                        "type": "boolean",
-                        "description": "Whether this character automatically moves up the train when possible."
-                    },
-                    "attack_damage": {
-                        "type": "integer",
-                        "description": "Base damage dealt by this character's attacks."
-                    },
-                    "attack_teleports_to_defender": {
-                        "type": "boolean",
-                        "description": "Whether this character teleports to its target when attacking."
-                    },
-                    "attack_vfx": {
-                        "type": "string",
-                        "description": "Visual effect played when this character attacks."
-                    },
-                    "block_size_increase": {
-                        "type": "boolean",
-                        "description": "Whether this character's size increases when blocking."
-                    },
-                    "boss_action_groups": {
-                        "type": "array",
-                        "description": "List of action groups for boss characters.",
-                        "items": {
-                            "properties": {
-                                "repeats": {
-                                    "type": "integer",
-                                    "description": "Number of times this action group repeats."
-                                },
-                                "actions": {
-                                    "type": "array",
-                                    "description": "List of actions in this group.",
-                                    "items": {
-                                        "properties": {
-                                            "name": {
-                                                "type": "string",
-                                                "description": "Name of this action."
-                                            },
-                                            "tooltip": {
-                                                "$ref": "../definitions/parse_term.json",
-                                                "description": "Localized text describing this action."
-                                            },
-                                            "team": {
-                                                "$ref": "../definitions/team.json",
-                                                "description": "Which team this action affects."
-                                            },
-                                            "effects": {
-                                                "type": "array",
-                                                "description": "List of effects this action applies.",
-                                                "items": {
-                                                    "properties": {
-                                                        "id": {
-                                                            "type": "string",
-                                                            "description": "Reference to an effect's unique identifier."
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "boss_cast_vfx": {
-                        "type": "string",
-                        "description": "Visual effect played when this boss character casts an ability."
-                    },
-                    "boss_room_cast_vfx": {
-                        "type": "string",
-                        "description": "Visual effect played in the room when this boss character casts an ability."
-                    },
-                    "can_attack": {
-                        "type": "boolean",
-                        "description": "Whether this character can perform attacks."
-                    },
-                    "can_be_healed": {
-                        "type": "boolean",
-                        "description": "Whether this character can receive healing."
-                    },
-                    "character_art": {
-                        "type": "string",
-                        "description": "Reference to the character's art asset."
-                    },
-                    "character_lore_tooltips": {
-                        "type": "array",
-                        "description": "List of lore tooltips for this character.",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "character_sound_data": {
-                        "type": "string",
-                        "description": "Reference to the character's sound data."
-                    },
-                    "chatter": {
-                        "type": "string",
-                        "description": "Reference to the character's dialogue data."
-                    },
-                    "chosen_variant": {
-                        "type": "boolean",
-                        "description": "Whether this is a chosen variant of the character."
-                    },
-                    "death_slides_backwards": {
-                        "type": "boolean",
-                        "description": "Whether this character slides backward when dying."
-                    },
-                    "death_type": {
-                        "$ref": "../definitions/death_type.json",
-                        "description": "Type of death animation to play."
-                    },
-                    "death_vfx": {
-                        "type": "string",
-                        "description": "Visual effect played when this character dies."
-                    },
-                    "disable_in_daily_challenges": {
-                        "type": "boolean",
-                        "description": "Whether this character is disabled in daily challenges."
-                    },
-                    "endless_stats": {
-                        "type": "object",
-                        "description": "Stats for this character in endless mode.",
-                        "properties": {
-                            "health": {
-                                "type": "integer",
-                                "description": "Health value in endless mode."
-                            },
-                            "attack": {
-                                "type": "integer",
-                                "description": "Attack value in endless mode."
-                            }
-                        },
-                        "required": [
-                            "health",
-                            "attack"
-                        ]
-                    },
-                    "enemy_relic": {
-                        "type": "string",
-                        "description": "Reference to a relic for the enemy's relic data."
-                    },
-                    "equip_limit": {
-                        "type": "integer",
-                        "description": "Maximum number of equipment this character can have."
-                    },
-                    "grafted_equipment": {
-                        "type": "string",
-                        "description": "Reference to this character's grafted equipment."
-                    },
-                    "health": {
-                        "type": "integer",
-                        "description": "Base health of this character."
-                    },
-                    "hide_in_logbook": {
-                        "type": "boolean",
-                        "description": "Whether this character should be hidden in the logbook."
-                    },
-                    "id": {
-                        "type": "string",
-                        "description": "Unique identifier for this character."
-                    },
-                    "impact_vfx": {
-                        "type": "string",
-                        "description": "Visual effect played when this character is hit."
-                    },
-                    "is_mini_boss": {
-                        "type": "boolean",
-                        "description": "Whether this character is a mini-boss."
-                    },
-                    "is_outer_train_boss": {
-                        "type": "boolean",
-                        "description": "Whether this character is an outer train boss."
-                    },
-                    "is_pyre": {
-                        "type": "boolean",
-                        "description": "Whether this character is the Pyre."
-                    },
-                    "loops_between_floors": {
-                        "type": "boolean",
-                        "description": "Whether this character loops between floors."
-                    },
-                    "names": {
-                        "$ref": "../definitions/parse_term.json",
-                        "description": "Localized text for this character's name."
-                    },
-                    "prevent_abilities_from_equipment": {
-                        "type": "boolean",
-                        "description": "Prevents ability from being overwritten by equipment"
-                    },
-                    "projectile_vfx": {
-                        "type": "string",
-                        "description": "Visual effect played for this character's projectiles."
-                    },
-                    "pyre_heart_data": {
-                        "type": "string",
-                        "description": "Reference to the Pyre heart data."
-                    },
-                    "room_modifiers": {
-                        "type": "array",
-                        "description": "List of room modifiers this character applies.",
-                        "items": {
-                            "required": [
-                                "id"
-                            ],
-                            "properties": {
-                                "id": {
-                                    "type": "string",
-                                    "description": "Reference to a room modifier's unique identifier."
-                                }
-                            }
-                        }
-                    },
-                    "size": {
-                        "type": "integer",
-                        "description": "Size of this character in the room."
-                    },
-                    "starting_status_effects": {
-                        "type": "array",
-                        "description": "List of status effects this character starts with.",
-                        "items": {
-                            "$ref": "../definitions/status_effect.json"
-                        }
-                    },
-                    "status_effect_immunities": {
-                        "type": "array",
-                        "description": "List of status effects this character is immune to.",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "subtypes": {
-                        "type": "array",
-                        "description": "List of subtypes this character belongs to.",
-                        "items": {
-                            "$ref": "../definitions/subtype.json"
-                        }
-                    },
-                    "titan_affinity": {
-                        "$ref": "../definitions/titan_affinity.json",
-                        "description": "This character's affinity with titans."
-                    },
-                    "triggers": {
-                        "type": "array",
-                        "uniqueItems": true,
-                        "description": "List of triggers this character has.",
-                        "items": {
-                            "required": [
-                                "id"
-                            ],
-                            "properties": {
-                                "id": {
-                                    "type": "string",
-                                    "description": "Reference to a trigger's unique identifier."
-                                }
-                            }
-                        }
-                    },
-                    "valid_attack_phase": {
-                        "type": "string",
-                        "description": "Phase during which this character can attack."
-                    }
-                },
-                "required": [
-                    "id"
-                ],
-                "description": "A character definition that specifies all properties and behaviors of a character in the game."
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Reference to a trigger's unique identifier."
+                }
+              }
             }
-        }
+          },
+          "valid_attack_phase": {
+            "type": "string",
+            "description": "Phase during which this character can attack."
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "description": "A character definition that specifies all properties and behaviors of a character in the game."
+      }
     }
+  }
 }

--- a/schemas/schemas/effects.json
+++ b/schemas/schemas/effects.json
@@ -11,193 +11,205 @@
                     "id",
                     "name"
                 ],
-                "properties": {
-                    "additional_tooltips": {
-                        "type": "array",
-                        "description": "Additional tooltips to display for this card effect.",
-                        "items": {
-                            "$ref": "../definitions/additonal_tooltips.json"
-                        }
-                    },
-                    "applied_to_self_vfx": {
-                        "type": "string",
-                        "description": "Reference to VFX to use when applying the card effect to self."
-                    },
-                    "applied_vfx": {
-                        "type": "string",
-                        "description": "Reference to VFX to use when applying the card effect."
-                    },
-                    "anim_to_play": {
-                        "$ref": "../definitions/anim.json",
-                        "description": "Animation to play when this effect is triggered."
-                    },
-                    "cancel_subsequent_effects_on_failure": {
-                        "type": "boolean",
-                        "description": "Whether to cancel all subsequent effects if this effect fails."
-                    },
-                    "copy_modifiers": {
-                        "type": "boolean",
-                        "description": "Whether to copy modifiers when applying this effect."
-                    },
-                    "fail_to_cast_on_failure": {
-                        "type": "boolean",
-                        "description": "Whether to fail the entire cast if this effect fails."
-                    },
-                    "filter_on_main_subclass": {
-                        "type": "boolean",
-                        "description": "Whether to filter based on the main subclass."
-                    },
-                    "hide_tooltip": {
-                        "type": "boolean",
-                        "description": "Whether to hide this card effect's tooltips."
-                    },
-                    "id": {
-                        "type": "string",
-                        "description": "Unique identifier for this effect."
-                    },
-                    "ignore_temporary_modifiers": {
-                        "type": "boolean",
-                        "description": "Whether to ignore temporary modifiers when applying this effect."
-                    },
-                    "mod_reference": {
-                        "type": "string",
-                        "description": "Mod GUID to search for a custom effect. If not specified then your Mod's assembly is searched."
-                    },
-                    "name": {
-                        "$ref": "../definitions/card_effect.json",
-                        "description": "The EffectStateName, this should be the name of a Class inheriting from CardEffectBase. Trainworks will search your mod for the class, then the base game."
-                    },
-                    "param_bool": {
-                        "type": "boolean",
-                        "description": "Boolean parameter for the effect."
-                    },
-                    "param_bool_2": {
-                        "type": "boolean",
-                        "description": "Second boolean parameter for the effect."
-                    },
-                    "param_card_pool": {
-                        "type": "string",
-                        "description": "Reference to CardPool for the effect."
-                    },
-                    "param_character_data": {
-                        "type": "string",
-                        "description": "Reference to character data for the effect."
-                    },
-                    "param_int": {
-                        "type": "integer",
-                        "description": "Integer parameter for the effect."
-                    },
-                    "param_int_2": {
-                        "type": "integer",
-                        "description": "Second integer parameter for the effect."
-                    },
-                    "param_int_3": {
-                        "type": "integer",
-                        "description": "Third integer parameter for the effect."
-                    },
-                    "param_max_int": {
-                        "type": "integer",
-                        "description": "Maximum integer value for the effect."
-                    },
-                    "param_min_int": {
-                        "type": "integer",
-                        "description": "Minimum integer value for the effect."
-                    },
-                    "param_multiplier": {
-                        "type": "number",
-                        "description": "Multiplier parameter for the effect. Defaults to 1.0"
-                    },
-                    "param_status_effects": {
-                        "type": "array",
-                        "description": "List of status effects to apply.",
-                        "items": {
-                            "$ref": "../definitions/status_effect.json"
-                        }
-                    },
-                    "param_str": {
-                        "type": "string",
-                        "description": "String parameter for the effect."
-                    },
-                    "param_subtypes": {
-                        "$ref": "../definitions/subtype.json",
-                        "description": "Subtype parameter for the effect. Defaults to SubtypesData_None."
-                    },
-                    "param_trigger": {
-                        "$ref": "../definitions/character_trigger.json",
-                        "description": "Trigger parameter for the effect."
-                    },
-                    "param_upgrade": {
-                        "type": "string",
-                        "description": "Reference to an upgrade to apply."
-                    },
-                    "should_test": {
-                        "type": "boolean",
-                        "description": "Whether this effect should be tested before applying."
-                    },
-                    "show_pyre_notification": {
-                        "type": "boolean",
-                        "description": "Whether to show a notification in the Pyre UI."
-                    },
-                    "status_effect_filters": {
-                        "type": "array",
-                        "description": "List of status effects to filter by.",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "status_effect_multiplier": {
-                        "type": "string",
-                        "description": "Status effect multiplier parameter."
-                    },
-                    "supress_pyre_room_focus": {
-                        "type": "boolean",
-                        "description": "Whether to suppress Pyre room focus when applying this effect."
-                    },
-                    "target_card_type": {
-                        "$ref": "../definitions/card_type_target.json",
-                        "description": "Type of card to target."
-                    },
-                    "target_ignore_bosses": {
-                        "type": "boolean",
-                        "description": "Whether to ignore boss characters when targeting."
-                    },
-                    "target_mode": {
-                        "$ref": "../definitions/target_mode.json",
-                        "description": "Mode for selecting targets."
-                    },
-                    "target_mode_health_filter": {
-                        "$ref": "../definitions/health_filter.json",
-                        "description": "Filter for target health when selecting targets."
-                    },
-                    "target_card_selection_mode": {
-                        "$ref": "../definitions/card_selection_mode.json",
-                        "description": "Used in CardEffectRecursion to choose how cards from target_mode are selected."
-                    },
-                    "target_subtype": {
-                        "$ref": "../definitions/subtype.json",
-                        "description": "Subtype to target. Defaults to SubtypesData_None"
-                    },
-                    "target_team": {
-                        "$ref": "../definitions/team.json",
-                        "description": "Team to target."
-                    },
-                    "use_health_missing_multiplier": {
-                        "type": "boolean",
-                        "description": "Whether to use missing health as a multiplier."
-                    },
-                    "use_int_range": {
-                        "type": "boolean",
-                        "description": "Whether to use an integer range for parameters."
-                    },
-                    "use_magic_power_multiplier": {
-                        "type": "boolean",
-                        "description": "Whether to use magic power as a multiplier."
-                    },
-                    "use_status_effect_multiplier": {
-                        "type": "boolean",
-                        "description": "Whether to use status effect count as a multiplier."
-                    }
+              "properties": {
+                "additional_tooltips": {
+                  "type": "array",
+                  "description": "Additional tooltips to display for this card effect.",
+                  "items": {
+                    "$ref": "../definitions/additonal_tooltips.json"
+                  }
                 },
+                "applied_to_self_vfx": {
+                  "type": "string",
+                  "description": "Reference to VFX to use when applying the card effect to self."
+                },
+                "applied_vfx": {
+                  "type": "string",
+                  "description": "Reference to VFX to use when applying the card effect."
+                },
+                "anim_to_play": {
+                  "$ref": "../definitions/anim.json",
+                  "description": "Animation to play when this effect is triggered."
+                },
+                "cancel_subsequent_effects_on_failure": {
+                  "type": "boolean",
+                  "description": "Whether to cancel all subsequent effects if this effect fails."
+                },
+                "copy_modifiers": {
+                  "type": "boolean",
+                  "description": "Whether to copy modifiers when applying this effect."
+                },
+                "disallow_status_effect_modifiers": {
+                  "type": "boolean",
+                  "description": "Disables modification of status effect stacks (Disables modification from Dualism, CardTraits, Relics, etc.)"
+                },
+                "fail_to_cast_on_failure": {
+                  "type": "boolean",
+                  "description": "Whether to fail the entire cast if this effect fails."
+                },
+                "filter_on_main_subclass": {
+                  "type": "boolean",
+                  "description": "Whether to filter based on the main subclass."
+                },
+                "hide_tooltip": {
+                  "type": "boolean",
+                  "description": "Whether to hide this card effect's tooltips."
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier for this effect."
+                },
+                "ignore_temporary_modifiers": {
+                  "type": "boolean",
+                  "description": "Whether to ignore temporary modifiers when applying this effect."
+                },
+                "mod_reference": {
+                  "type": "string",
+                  "description": "Mod GUID to search for a custom effect. If not specified then your Mod's assembly is searched."
+                },
+                "name": {
+                  "$ref": "../definitions/card_effect.json",
+                  "description": "The EffectStateName, this should be the name of a Class inheriting from CardEffectBase. Trainworks will search your mod for the class, then the base game."
+                },
+                "param_bool": {
+                  "type": "boolean",
+                  "description": "Boolean parameter for the effect."
+                },
+                "param_bool_2": {
+                  "type": "boolean",
+                  "description": "Second boolean parameter for the effect."
+                },
+                "param_card_filter": {
+                  "type": "string",
+                  "description": "Reference to a CardUpgradeMaskData. Used in certain effects to filter out target cards."
+                },
+                "param_card_filter_2": {
+                  "type": "string",
+                  "description": "Reference to a CardUpgradeMaskData. A Secondary filter used in certain effects to filter out target cards (Currently only used by CardEffectDrawType)."
+                },
+                "param_card_pool": {
+                  "type": "string",
+                  "description": "Reference to CardPool for the effect."
+                },
+                "param_character_data": {
+                  "type": "string",
+                  "description": "Reference to character data for the effect."
+                },
+                "param_int": {
+                  "type": "integer",
+                  "description": "Integer parameter for the effect."
+                },
+                "param_int_2": {
+                  "type": "integer",
+                  "description": "Second integer parameter for the effect."
+                },
+                "param_int_3": {
+                  "type": "integer",
+                  "description": "Third integer parameter for the effect."
+                },
+                "param_max_int": {
+                  "type": "integer",
+                  "description": "Maximum integer value for the effect."
+                },
+                "param_min_int": {
+                  "type": "integer",
+                  "description": "Minimum integer value for the effect."
+                },
+                "param_multiplier": {
+                  "type": "number",
+                  "description": "Multiplier parameter for the effect. Defaults to 1.0"
+                },
+                "param_status_effects": {
+                  "type": "array",
+                  "description": "List of status effects to apply.",
+                  "items": {
+                    "$ref": "../definitions/status_effect.json"
+                  }
+                },
+                "param_str": {
+                  "type": "string",
+                  "description": "String parameter for the effect."
+                },
+                "param_subtypes": {
+                  "$ref": "../definitions/subtype.json",
+                  "description": "Subtype parameter for the effect. Defaults to SubtypesData_None."
+                },
+                "param_trigger": {
+                  "$ref": "../definitions/character_trigger.json",
+                  "description": "Trigger parameter for the effect."
+                },
+                "param_upgrade": {
+                  "type": "string",
+                  "description": "Reference to an upgrade to apply."
+                },
+                "should_test": {
+                  "type": "boolean",
+                  "description": "Whether this effect should be tested before applying."
+                },
+                "show_pyre_notification": {
+                  "type": "boolean",
+                  "description": "Whether to show a notification in the Pyre UI."
+                },
+                "status_effect_filters": {
+                  "type": "array",
+                  "description": "List of status effects to filter by.",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "status_effect_multiplier": {
+                  "type": "string",
+                  "description": "Status effect multiplier parameter."
+                },
+                "supress_pyre_room_focus": {
+                  "type": "boolean",
+                  "description": "Whether to suppress Pyre room focus when applying this effect."
+                },
+                "target_card_type": {
+                  "$ref": "../definitions/card_type_target.json",
+                  "description": "Type of card to target."
+                },
+                "target_ignore_bosses": {
+                  "type": "boolean",
+                  "description": "Whether to ignore boss characters when targeting."
+                },
+                "target_mode": {
+                  "$ref": "../definitions/target_mode.json",
+                  "description": "Mode for selecting targets."
+                },
+                "target_mode_health_filter": {
+                  "$ref": "../definitions/health_filter.json",
+                  "description": "Filter for target health when selecting targets."
+                },
+                "target_card_selection_mode": {
+                  "$ref": "../definitions/card_selection_mode.json",
+                  "description": "Used in CardEffectRecursion to choose how cards from target_mode are selected."
+                },
+                "target_subtype": {
+                  "$ref": "../definitions/subtype.json",
+                  "description": "Subtype to target. Defaults to SubtypesData_None"
+                },
+                "target_team": {
+                  "$ref": "../definitions/team.json",
+                  "description": "Team to target."
+                },
+                "use_health_missing_multiplier": {
+                  "type": "boolean",
+                  "description": "Whether to use missing health as a multiplier."
+                },
+                "use_int_range": {
+                  "type": "boolean",
+                  "description": "Whether to use an integer range for parameters."
+                },
+                "use_magic_power_multiplier": {
+                  "type": "boolean",
+                  "description": "Whether to use magic power as a multiplier."
+                },
+                "use_status_effect_multiplier": {
+                  "type": "boolean",
+                  "description": "Whether to use status effect count as a multiplier."
+                }
+              },
                 "description": "An effect definition that specifies how a card or ability affects the game state."
             }
         }

--- a/schemas/schemas/enhancer_pools.json
+++ b/schemas/schemas/enhancer_pools.json
@@ -1,0 +1,31 @@
+{
+    "$id": "https://raw.githubusercontent.com/Monster-Train-2-Modding-Group/Trainworks-Reloaded/refs/heads/main/schemas/schemas/enhancer_pools.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+        "enhancer_pools": {
+            "type": "array",
+            "uniqueItems": true,
+            "description": "A collection of enhancer pools that define which enhancers (shop upgrades) can appear in specific situations or rewards.",
+            "items": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier for this enhancer pool. Used to reference this pool from other parts of the game."
+                    },
+                    "enhancers": {
+                        "items": {
+                            "type": "string",
+                            "description": "Reference to an enhancer's unique identifier that can appear in this pool."
+                        },
+                        "type": "array",
+                        "description": "List of enhancers references that can appear in this pool."
+                    }
+                },
+                "required": [
+                    "id"
+                ],
+                "description": "A enhancer pool definition that specifies which enhancers can appear together."
+            }
+        }
+    }
+}

--- a/schemas/schemas/relic_effects.json
+++ b/schemas/schemas/relic_effects.json
@@ -1,263 +1,267 @@
 {
-    "$id": "https://raw.githubusercontent.com/Monster-Train-2-Modding-Group/Trainworks-Reloaded/refs/heads/main/schemas/schemas/relic_effects.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "properties": {
-        "relic_effects": {
+  "$id": "https://raw.githubusercontent.com/Monster-Train-2-Modding-Group/Trainworks-Reloaded/refs/heads/main/schemas/schemas/relic_effects.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "relic_effects": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [ "id", "name" ],
+        "properties": {
+          "additional_tooltips": {
+            "type": "array",
+            "description": "Additional tooltips to display for this card effect.",
+            "items": {
+              "$ref": "../definitions/additonal_tooltips.json"
+            }
+          },
+          "applied_vfx": {
+            "type": "string",
+            "description": "Reference to VFX to use when applying the effect to a character"
+          },
+          "card_rarity_type": {
+            "$ref": "../definitions/rarity.json",
+            "description": "Card rarity type parameter"
+          },
+          "card_triggers": {
             "type": "array",
             "items": {
-                "type": "object",
-                "required": ["id", "name"],
-                "properties": {
-                    "additional_tooltips": {
-                        "type": "array",
-                        "description": "Additional tooltips to display for this card effect.",
-                        "items": {
-                            "$ref": "../definitions/additonal_tooltips.json"
-                        }
-                    },
-                    "applied_vfx": {
-                        "type": "string",
-                        "description": "Reference to VFX to use when applying the effect to a character"
-                    },
-                    "id": {
-                        "type": "string",
-                        "description": "Unique identifier for the relic effect"
-                    },
-                    "name": {
-                        "$ref": "../definitions/relic_effect.json",
-                        "description": "The RelicEffectStateName, this should be the name of a Class inheriting from RelicEffectBase"
-                    },
-                    "mod_reference": {
-                        "type": "string",
-                        "description": "Mod GUID to search for a custom relic effect. If not specified then your Mod's assembly is searched."
-                    },
-                    "tooltip_titles": {
-                        "$ref": "../definitions/parse_term.json",
-                        "description": "Localization data for the relic effect's tooltip title"
-                    },
-                    "tooltip_body": {
-                        "$ref": "../definitions/parse_term.json",
-                        "description": "Localization data for the relic effect's tooltip body"
-                    },
-                    "source_team": {
-                        "$ref": "../definitions/team.json",
-                        "description": "Source team for the relic effect"
-                    },
-                    "param_int": {
-                        "type": "integer",
-                        "description": "Primary integer parameter"
-                    },
-                    "param_int_2": {
-                        "type": "integer",
-                        "description": "Secondary integer parameter"
-                    },
-                    "param_float": {
-                        "type": "number",
-                        "description": "Float parameter"
-                    },
-                    "use_int_range": {
-                        "type": "boolean",
-                        "description": "Whether to use integer range parameters"
-                    },
-                    "min_int": {
-                        "type": "integer",
-                        "description": "When use_int_range is true. Minimum integer value for range"
-                    },
-                    "max_int": {
-                        "type": "integer",
-                        "description": "When use_int_range is true. Maximum integer value for range"
-                    },
-                    "param_string": {
-                        "type": "string",
-                        "description": "String parameter"
-                    },
-                    "character_subtype": {
-                        "type": "string",
-                        "description": "Character subtype parameter"
-                    },
-                    "excluded_character_subtypes": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "description": "Array of excluded character subtypes"
-                    },
-                    "special_character_type": {
-                        "$ref": "../definitions/special_character_type.json",
-                        "description": "Special character type parameter"
-                    },
-                    "param_bool": {
-                        "type": "boolean",
-                        "description": "Primary boolean parameter"
-                    },
-                    "param_bool_2": {
-                        "type": "boolean",
-                        "description": "Secondary boolean parameter"
-                    },
-                    "param_bool_3": {
-                        "type": "boolean",
-                        "description": "Tertiary boolean parameter"
-                    },
-                    "target_mode": {
-                        "$ref": "../definitions/target_mode.json",
-                        "description": "Target mode for the effect"
-                    },
-                    "card_type": {
-                        "$ref": "../definitions/card_type.json",
-                        "description": "Card type parameter"
-                    },
-                    "notification_suppressed": {
-                        "type": "boolean",
-                        "description": "Whether to suppress notifications"
-                    },
-                    "trigger_tooltips_suppressed": {
-                        "type": "boolean",
-                        "description": "Whether to suppress trigger tooltips"
-                    },
-                    "relic_scaling_count": {
-                        "type": "integer",
-                        "description": "Scaling count for the relic"
-                    },
-                    "source_card_trait": {
-                        "type": "string",
-                        "description": "Source card trait parameter"
-                    },
-                    "target_card_trait": {
-                        "type": "string",
-                        "description": "Target card trait parameter"
-                    },
-                    "rarity_ticket_type": {
-                        "$ref": "../definitions/rarity_ticket.json",
-                        "description": "Rarity ticket type parameter"
-                    },
-                    "card_rarity_type": {
-                        "$ref": "../definitions/rarity.json",
-                        "description": "Card rarity type parameter"
-                    },
-                    "card_triggers": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "../definitions/card_trigger.json"
-                        },
-                        "description": "Array of card triggers"
-                    },
-                    "param_trigger": {
-                        "$ref": "../definitions/character_trigger.json",
-                        "description": "Trigger parameter for the relic effect."
-                    },
-                    "param_status_effects": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "../definitions/status_effect.json"
-                        },
-                        "description": "Array of status effects with their counts"
-                    },
-                    "param_card_effects": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": ["id"],
-                            "properties": {
-                                "id": {
-                                    "type": "string",
-                                    "description": "Card effect identifier"
-                                }
-                            }
-                        },
-                        "description": "Array of card effects"
-                    },
-                    "param_card_pool": {
-                        "type": "string",
-                        "description": "Card pool identifier"
-                    },
-                    "param_characters": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": ["id"],
-                            "properties": {
-                                "id": {
-                                    "type": "string",
-                                    "description": "Character identifier"
-                                }
-                            }
-                        },
-                        "description": "Array of characters"
-                    },
-                    "traits": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": ["id"],
-                            "properties": {
-                                "id": {
-                                    "type": "string",
-                                    "description": "Trait identifier"
-                                }
-                            }
-                        },
-                        "description": "Array of traits"
-                    },
-                    "excluded_traits": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": ["id"],
-                            "properties": {
-                                "id": {
-                                    "type": "string",
-                                    "description": "Trait identifier"
-                                }
-                            }
-                        },
-                        "description": "Array of excluded traits"
-                    },
-                    "triggers": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": ["id"],
-                            "properties": {
-                                "id": {
-                                    "type": "string",
-                                    "description": "Trigger identifier"
-                                }
-                            }
-                        },
-                        "description": "Array of triggers"
-                    },
-                    "param_card_data": {
-                        "type": "string",
-                        "description": "Card data identifier"
-                    },
-                    "param_upgrade": {
-                        "type": "string",
-                        "description": "Card upgrade data identifier"
-                    },
-                    "param_relic": {
-                        "type": "string",
-                        "description": "Relic data identifier"
-                    },
-                    "param_reward": {
-                        "type": "string",
-                        "description": "Reward identifier"
-                    },
-                    "param_reward_2": {
-                        "type": "string",
-                        "description": "Secondary reward identifier"
-                    },
-                    "param_card_filter": {
-                        "type": "string",
-                        "description": "Card filter identifier"
-                    },
-                    "param_card_filter_secondary": {
-                        "type": "string",
-                        "description": "Secondary card filter identifier"
-                    }
-                }
+              "$ref": "../definitions/card_trigger.json"
             },
-            "description": "Array of relic effect definitions"
+            "description": "Array of card triggers"
+          },
+          "card_type": {
+            "$ref": "../definitions/card_type.json",
+            "description": "Card type parameter"
+          },
+          "character_subtype": {
+            "type": "string",
+            "description": "Character subtype parameter"
+          },
+          "excluded_character_subtypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Array of excluded character subtypes"
+          },
+          "excluded_traits": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [ "id" ],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Trait identifier"
+                }
+              }
+            },
+            "description": "Array of excluded traits"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the relic effect"
+          },
+          "max_int": {
+            "type": "integer",
+            "description": "When use_int_range is true. Maximum integer value for range"
+          },
+          "min_int": {
+            "type": "integer",
+            "description": "When use_int_range is true. Minimum integer value for range"
+          },
+          "mod_reference": {
+            "type": "string",
+            "description": "Mod GUID to search for a custom relic effect. If not specified then your Mod's assembly is searched."
+          },
+          "name": {
+            "$ref": "../definitions/relic_effect.json",
+            "description": "The RelicEffectStateName, this should be the name of a Class inheriting from RelicEffectBase"
+          },
+          "notification_suppressed": {
+            "type": "boolean",
+            "description": "Whether to suppress notifications"
+          },
+          "param_bool": {
+            "type": "boolean",
+            "description": "Primary boolean parameter"
+          },
+          "param_bool_2": {
+            "type": "boolean",
+            "description": "Secondary boolean parameter"
+          },
+          "param_bool_3": {
+            "type": "boolean",
+            "description": "Tertiary boolean parameter"
+          },
+          "param_card_data": {
+            "type": "string",
+            "description": "Card data identifier"
+          },
+          "param_card_effects": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [ "id" ],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Card effect identifier"
+                }
+              }
+            },
+            "description": "Array of card effects"
+          },
+          "param_card_filter": {
+            "type": "string",
+            "description": "Card filter identifier"
+          },
+          "param_card_filter_secondary": {
+            "type": "string",
+            "description": "Secondary card filter identifier"
+          },
+          "param_card_pool": {
+            "type": "string",
+            "description": "Card pool identifier"
+          },
+          "param_characters": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [ "id" ],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Character identifier"
+                }
+              }
+            },
+            "description": "Array of characters"
+          },
+          "param_enhancer_pool": {
+            "type": "string",
+            "description": "Reference to EnhancerPool."
+          },
+          "param_float": {
+            "type": "number",
+            "description": "Float parameter"
+          },
+          "param_int": {
+            "type": "integer",
+            "description": "Primary integer parameter"
+          },
+          "param_int_2": {
+            "type": "integer",
+            "description": "Secondary integer parameter"
+          },
+          "param_relic": {
+            "type": "string",
+            "description": "Relic data identifier"
+          },
+          "param_reward": {
+            "type": "string",
+            "description": "Reward identifier"
+          },
+          "param_reward_2": {
+            "type": "string",
+            "description": "Secondary reward identifier"
+          },
+          "param_status_effects": {
+            "type": "array",
+            "items": {
+              "$ref": "../definitions/status_effect.json"
+            },
+            "description": "Array of status effects with their counts"
+          },
+          "param_string": {
+            "type": "string",
+            "description": "String parameter"
+          },
+          "param_trigger": {
+            "$ref": "../definitions/character_trigger.json",
+            "description": "Trigger parameter for the relic effect."
+          },
+          "param_upgrade": {
+            "type": "string",
+            "description": "Card upgrade data identifier"
+          },
+          "rarity_ticket_type": {
+            "$ref": "../definitions/rarity_ticket.json",
+            "description": "Rarity ticket type parameter"
+          },
+          "relic_scaling_count": {
+            "type": "integer",
+            "description": "Scaling count for the relic"
+          },
+          "source_card_trait": {
+            "type": "string",
+            "description": "Source card trait parameter"
+          },
+          "source_team": {
+            "$ref": "../definitions/team.json",
+            "description": "Source team for the relic effect"
+          },
+          "special_character_type": {
+            "$ref": "../definitions/special_character_type.json",
+            "description": "Special character type parameter"
+          },
+          "target_card_trait": {
+            "type": "string",
+            "description": "Target card trait parameter"
+          },
+          "target_mode": {
+            "$ref": "../definitions/target_mode.json",
+            "description": "Target mode for the effect"
+          },
+          "tooltip_body": {
+            "$ref": "../definitions/parse_term.json",
+            "description": "Localization data for the relic effect's tooltip body"
+          },
+          "tooltip_titles": {
+            "$ref": "../definitions/parse_term.json",
+            "description": "Localization data for the relic effect's tooltip title"
+          },
+          "traits": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [ "id" ],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Trait identifier"
+                }
+              }
+            },
+            "description": "Array of traits"
+          },
+          "trigger_tooltips_suppressed": {
+            "type": "boolean",
+            "description": "Whether to suppress trigger tooltips"
+          },
+          "triggers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [ "id" ],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Trigger identifier"
+                }
+              }
+            },
+            "description": "Array of triggers"
+          },
+          "use_int_range": {
+            "type": "boolean",
+            "description": "Whether to use integer range parameters"
+          }
         }
+      },
+      "description": "Array of relic effect definitions"
     }
+  },
+  "type": "object"
 }

--- a/schemas/schemas/relic_pools.json
+++ b/schemas/schemas/relic_pools.json
@@ -1,0 +1,31 @@
+{
+    "$id": "https://raw.githubusercontent.com/Monster-Train-2-Modding-Group/Trainworks-Reloaded/refs/heads/main/schemas/schemas/relic_pools.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+        "relic_pools": {
+            "type": "array",
+            "uniqueItems": true,
+            "description": "A collection of relic pools that define which collectable relics can appear in specific situations or rewards.",
+            "items": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier for this relic pool. Used to reference this pool from other parts of the game."
+                    },
+                    "relics": {
+                        "items": {
+                            "type": "string",
+                            "description": "Reference to an relic's unique identifier that can appear in this pool (must be a collectable)."
+                        },
+                        "type": "array",
+                        "description": "List of relics references that can appear in this pool."
+                    }
+                },
+                "required": [
+                    "id"
+                ],
+                "description": "A relic pool definition that specifies which collectable  relics can appear together."
+            }
+        }
+    }
+}

--- a/schemas/schemas/relics.json
+++ b/schemas/schemas/relics.json
@@ -143,13 +143,16 @@
                               "description": "Whether to force update the count label for this relic",
                               "default": false
                             },
-                            "pool": {
-                              "type": "string",
-                              "description": "Pool to add this relic to",
-                              "enum": [
-                                "megapool",
-                                null
-                              ]
+                            "pools": {
+                              "type": "array",
+                              "description": "Pools to add this relic to",
+                              "items":{
+                                "type": "string",
+                                "enum": [
+                                  "megapool",
+                                  null
+                                ]
+                              }
                             }
                           }
                         }

--- a/schemas/schemas/relics.json
+++ b/schemas/schemas/relics.json
@@ -146,7 +146,7 @@
                             "pools": {
                               "type": "array",
                               "description": "Pools to add this relic to",
-                              "items":{
+                              "items": {
                                 "type": "string",
                                 "enum": [
                                   "megapool",


### PR DESCRIPTION
## Summary
EnhancerPools and RelicPools and updates from 05/05 demo update

## Changes
- EnhancerPools and wiring of ClassData.randomDraftEnhancerPool and RelicEffectData.paramEnhancerPool
- RelicPools
- new fields introduced from the 05/05 demo update

## Test JSON

## Checklist
- [x] enhancer_pools
- [x] relic_pools
- [x] upgrades.exclude_from_clones
- [x] characters.artist
- [x] effects.disallow_status_effect_modifiers
- [x] effects.param_card_filter_2
- [x] relic_effects.param_enhancer_pool
- [x] relics.pools  (relics.pool now prints a warning message since it will be renamed to this).

## Related Issues
Closes #57 
Closes #49 
