### PR TITLE
Additional logging and override fixes.

### DIFF
--- a/TrainworksReloaded.Base/Card/CardDataPipeline.cs
+++ b/TrainworksReloaded.Base/Card/CardDataPipeline.cs
@@ -203,15 +203,12 @@ namespace TrainworksReloaded.Base.Card
                 .Field(typeof(CardData), "cooldownAfterActivated")
                 .SetValue(data, configuration.GetSection("cooldown").ParseInt() ?? defaultCooldown);
 
-            var defaultAbility =
-                checkOverride
-                && (bool)AccessTools.Field(typeof(CardData), "isUnitAbility").GetValue(data);
+            var defaultAbility = (bool)AccessTools.Field(typeof(CardData), "isUnitAbility").GetValue(data);
             AccessTools
                 .Field(typeof(CardData), "isUnitAbility")
                 .SetValue(data, configuration.GetDeprecatedSection("ability", "is_an_ability").ParseBool() ?? defaultAbility);
 
-            var defaultTargetsRoom =
-                checkOverride ? (bool)AccessTools.Field(typeof(CardData), "targetsRoom").GetValue(data) : true;
+            var defaultTargetsRoom = (bool)AccessTools.Field(typeof(CardData), "targetsRoom").GetValue(data);
             AccessTools
                 .Field(typeof(CardData), "targetsRoom")
                 .SetValue(
@@ -219,9 +216,7 @@ namespace TrainworksReloaded.Base.Card
                     configuration.GetSection("targets_room").ParseBool() ?? defaultTargetsRoom
                 );
 
-            var defaultTargetless =
-                checkOverride
-                && (bool)AccessTools.Field(typeof(CardData), "targetless").GetValue(data);
+            var defaultTargetless = (bool)AccessTools.Field(typeof(CardData), "targetless").GetValue(data);
             AccessTools
                 .Field(typeof(CardData), "targetless")
                 .SetValue(
@@ -253,10 +248,7 @@ namespace TrainworksReloaded.Base.Card
                     configuration.GetSection("unlock_level").ParseInt() ?? defaultUnlockLevel
                 );
 
-            var ignoreWhenCountingMastery =
-                checkOverride
-                && (bool)
-                    AccessTools.Field(typeof(CardData), "ignoreWhenCountingMastery").GetValue(data);
+            var ignoreWhenCountingMastery = (bool)AccessTools.Field(typeof(CardData), "ignoreWhenCountingMastery").GetValue(data);
             AccessTools
                 .Field(typeof(CardData), "ignoreWhenCountingMastery")
                 .SetValue(
@@ -265,9 +257,7 @@ namespace TrainworksReloaded.Base.Card
                         ?? ignoreWhenCountingMastery
                 );
 
-            var hideInLogbook =
-                checkOverride
-                && (bool)AccessTools.Field(typeof(CardData), "hideInLogbook").GetValue(data);
+            var hideInLogbook = (bool)AccessTools.Field(typeof(CardData), "hideInLogbook").GetValue(data);
             AccessTools
                 .Field(typeof(CardData), "hideInLogbook")
                 .SetValue(
@@ -287,12 +277,7 @@ namespace TrainworksReloaded.Base.Card
                         ?? initialKeyboardTarget
                 );
 
-            var canAbilityTargetOtherFloors =
-                checkOverride
-                && (bool)
-                    AccessTools
-                        .Field(typeof(CardData), "canAbilityTargetOtherFloors")
-                        .GetValue(data);
+            var canAbilityTargetOtherFloors = (bool)AccessTools.Field(typeof(CardData), "canAbilityTargetOtherFloors").GetValue(data);
             AccessTools
                 .Field(typeof(CardData), "canAbilityTargetOtherFloors")
                 .SetValue(

--- a/TrainworksReloaded.Base/CardUpgrade/CardUpgradeMaskPipeline.cs
+++ b/TrainworksReloaded.Base/CardUpgrade/CardUpgradeMaskPipeline.cs
@@ -200,7 +200,7 @@ namespace TrainworksReloaded.Base.CardUpgrade
             List<string> requiredEffects = [];
             foreach (var child in configuration.GetSection("required_effects").GetChildren())
             {
-                var effectType = ParseEffectType<CardEffectBase>(child, key, atlas);
+                var effectType = ParseEffectType<CardEffectBase>(child, key, atlas, id);
                 if (effectType != null)
                 {
                     requiredEffects.Add(effectType);
@@ -211,7 +211,7 @@ namespace TrainworksReloaded.Base.CardUpgrade
             List<string> excludedEffects = [];
             foreach (var child in configuration.GetSection("excluded_effects").GetChildren())
             {
-                var effectType = ParseEffectType<CardEffectBase>(child, key, atlas);
+                var effectType = ParseEffectType<CardEffectBase>(child, key, atlas, id);
                 if (effectType != null)
                 {
                     excludedEffects.Add(effectType);
@@ -222,7 +222,7 @@ namespace TrainworksReloaded.Base.CardUpgrade
             List<string> requiredTraits = [];
             foreach (var child in configuration.GetSection("required_traits").GetChildren())
             {
-                var effectType = ParseEffectType<CardTraitState>(child, key, atlas);
+                var effectType = ParseEffectType<CardTraitState>(child, key, atlas, id);
                 if (effectType != null)
                 {
                     requiredTraits.Add(effectType);
@@ -233,7 +233,7 @@ namespace TrainworksReloaded.Base.CardUpgrade
             List<string> excludedTraits = [];
             foreach (var child in configuration.GetSection("excluded_traits").GetChildren())
             {
-                var effectType = ParseEffectType<CardTraitState>(child, key, atlas);
+                var effectType = ParseEffectType<CardTraitState>(child, key, atlas, id);
                 if (effectType != null)
                 {
                     excludedTraits.Add(effectType);
@@ -242,10 +242,13 @@ namespace TrainworksReloaded.Base.CardUpgrade
             AccessTools.Field(typeof(CardUpgradeMaskData), "excludedCardTraits").SetValue(data, excludedTraits);
 
             service.Register(name, data);
-            return new CardUpgradeMaskDefinition(key, data, configuration);
+            return new CardUpgradeMaskDefinition(key, data, configuration)
+            {
+                Id = id
+            };
         }
 
-        private string? ParseEffectType<T>(IConfigurationSection configuration, string key, PluginAtlas atlas)
+        private string? ParseEffectType<T>(IConfigurationSection configuration, string key, PluginAtlas atlas, string id)
         {
             var reference = configuration.ParseReference();
             if (reference == null)
@@ -257,6 +260,7 @@ namespace TrainworksReloaded.Base.CardUpgrade
             {
                 return fullyQualifiedName;
             }
+            logger.Log(LogLevel.Warning, $"Failed to load class name {name} in upgrade_mask {id} with mod reference {modReference}, Note that this isn't a reference, but a class that inherits from {typeof(T).Name}.");
             return null;
         }
     }

--- a/TrainworksReloaded.Base/CardUpgrade/CardUpgradePipeline.cs
+++ b/TrainworksReloaded.Base/CardUpgrade/CardUpgradePipeline.cs
@@ -323,9 +323,6 @@ namespace TrainworksReloaded.Base.CardUpgrade
             foreach (var reference in upgradeReferences)
             {
                 var traitStateName = reference.id;
-                if (traitStateName == null)
-                    continue;
-
                 var modReference = reference.mod_reference ?? key;
                 var assembly = atlas.PluginDefinitions.GetValueOrDefault(modReference)?.Assembly;
                 if (
@@ -335,6 +332,7 @@ namespace TrainworksReloaded.Base.CardUpgrade
                     )
                 )
                 {
+                    logger.Log(LogLevel.Warning, $"Failed to load trait state name {traitStateName} in upgrade {id} with mod reference {modReference}, Note that this isn't a reference to a CardTraitData, but a class that inherits from CardTraitState.");
                     continue;
                 }
                 removeTraitUpgrades.Add(fullyQualifiedName);

--- a/TrainworksReloaded.Base/CardUpgrade/CardUpgradePipeline.cs
+++ b/TrainworksReloaded.Base/CardUpgrade/CardUpgradePipeline.cs
@@ -147,9 +147,7 @@ namespace TrainworksReloaded.Base.CardUpgrade
 
             //bools
             var allowSecondaryTooltipPlacement =
-                checkOverride
-                && (bool)
-                    AccessTools
+                    (bool)AccessTools
                         .Field(typeof(CardUpgradeData), "allowSecondaryTooltipPlacement")
                         .GetValue(data);
             AccessTools
@@ -161,9 +159,7 @@ namespace TrainworksReloaded.Base.CardUpgrade
                 );
 
             var hideUpgradeIconOnCard =
-                checkOverride
-                && (bool)
-                    AccessTools
+                (bool)AccessTools
                         .Field(typeof(CardUpgradeData), "hideUpgradeIconOnCard")
                         .GetValue(data);
             AccessTools
@@ -175,9 +171,7 @@ namespace TrainworksReloaded.Base.CardUpgrade
                 );
 
             var useUpgradeHighlightTextTags =
-                checkOverride
-                || (bool)
-                    AccessTools
+                (bool)AccessTools
                         .Field(typeof(CardUpgradeData), "useUpgradeHighlightTextTags")
                         .GetValue(data);
             AccessTools
@@ -189,9 +183,7 @@ namespace TrainworksReloaded.Base.CardUpgrade
                 );
 
             var showUpgradeDescriptionOnCards =
-                checkOverride
-                && (bool)
-                    AccessTools
+                (bool)AccessTools
                         .Field(typeof(CardUpgradeData), "showUpgradeDescriptionOnCards")
                         .GetValue(data);
             AccessTools
@@ -202,17 +194,13 @@ namespace TrainworksReloaded.Base.CardUpgrade
                         ?? showUpgradeDescriptionOnCards
                 );
 
-            var isUnique =
-                checkOverride
-                && (bool)AccessTools.Field(typeof(CardUpgradeData), "isUnique").GetValue(data);
+            var isUnique = (bool)AccessTools.Field(typeof(CardUpgradeData), "isUnique").GetValue(data);
             AccessTools
                 .Field(typeof(CardUpgradeData), "isUnique")
                 .SetValue(data, configuration.GetSection("is_unique").ParseBool() ?? isUnique);
 
             var restrictSizeToRoomCapacity =
-                checkOverride
-                && (bool)
-                    AccessTools
+                   (bool)AccessTools
                         .Field(typeof(CardUpgradeData), "restrictSizeToRoomCapacity")
                         .GetValue(data);
             AccessTools
@@ -224,9 +212,7 @@ namespace TrainworksReloaded.Base.CardUpgrade
                 );
 
             var doNotReplaceExistingUnitAbility =
-                checkOverride
-                && (bool)
-                    AccessTools
+                (bool)AccessTools
                         .Field(typeof(CardUpgradeData), "doNotReplaceExistingUnitAbility")
                         .GetValue(data);
             AccessTools

--- a/TrainworksReloaded.Base/Character/CharacterDataPipeline.cs
+++ b/TrainworksReloaded.Base/Character/CharacterDataPipeline.cs
@@ -116,9 +116,7 @@ namespace TrainworksReloaded.Base.Character
             }
 
             //bools
-            var hideInLogbook =
-                checkOverride
-                && (bool)AccessTools.Field(typeof(CharacterData), "hideInLogbook").GetValue(data);
+            var hideInLogbook = (bool)AccessTools.Field(typeof(CharacterData), "hideInLogbook").GetValue(data);
             AccessTools
                 .Field(typeof(CharacterData), "hideInLogbook")
                 .SetValue(
@@ -126,9 +124,7 @@ namespace TrainworksReloaded.Base.Character
                     configuration.GetSection("hide_in_logbook").ParseBool() ?? hideInLogbook
                 );
 
-            var blockVisualSizeIncrease =
-                checkOverride
-                && (bool)
+            var blockVisualSizeIncrease = (bool)
                     AccessTools
                         .Field(typeof(CharacterData), "blockVisualSizeIncrease")
                         .GetValue(data);
@@ -140,9 +136,7 @@ namespace TrainworksReloaded.Base.Character
                         ?? blockVisualSizeIncrease
                 );
 
-            var canBeHealed =
-                checkOverride
-                && (bool)AccessTools.Field(typeof(CharacterData), "canBeHealed").GetValue(data);
+            var canBeHealed = (bool)AccessTools.Field(typeof(CharacterData), "canBeHealed").GetValue(data);
             AccessTools
                 .Field(typeof(CharacterData), "canBeHealed")
                 .SetValue(
@@ -150,10 +144,7 @@ namespace TrainworksReloaded.Base.Character
                     configuration.GetSection("can_be_healed").ParseBool() ?? canBeHealed
                 );
 
-            var isOuterTrainBoss =
-                checkOverride
-                && (bool)
-                    AccessTools.Field(typeof(CharacterData), "isOuterTrainBoss").GetValue(data);
+            var isOuterTrainBoss = (bool) AccessTools.Field(typeof(CharacterData), "isOuterTrainBoss").GetValue(data);
             AccessTools
                 .Field(typeof(CharacterData), "isOuterTrainBoss")
                 .SetValue(
@@ -161,26 +152,17 @@ namespace TrainworksReloaded.Base.Character
                     configuration.GetSection("is_outer_train_boss").ParseBool() ?? isOuterTrainBoss
                 );
 
-            var isMiniboss =
-                checkOverride
-                && (bool)AccessTools.Field(typeof(CharacterData), "isMiniboss").GetValue(data);
+            var isMiniboss = (bool)AccessTools.Field(typeof(CharacterData), "isMiniboss").GetValue(data);
             AccessTools
                 .Field(typeof(CharacterData), "isMiniboss")
                 .SetValue(data, configuration.GetSection("is_mini_boss").ParseBool() ?? isMiniboss);
 
-            var canAttack =
-                checkOverride
-                && (bool)AccessTools.Field(typeof(CharacterData), "canAttack").GetValue(data);
+            var canAttack = (bool)AccessTools.Field(typeof(CharacterData), "canAttack").GetValue(data);
             AccessTools
                 .Field(typeof(CharacterData), "canAttack")
                 .SetValue(data, configuration.GetSection("can_attack").ParseBool() ?? canAttack);
 
-            var ascendsTrainAutomatically =
-                checkOverride
-                && (bool)
-                    AccessTools
-                        .Field(typeof(CharacterData), "ascendsTrainAutomatically")
-                        .GetValue(data);
+            var ascendsTrainAutomatically = (bool) AccessTools.Field(typeof(CharacterData), "ascendsTrainAutomatically").GetValue(data);
             AccessTools
                 .Field(typeof(CharacterData), "ascendsTrainAutomatically")
                 .SetValue(
@@ -189,12 +171,7 @@ namespace TrainworksReloaded.Base.Character
                         ?? ascendsTrainAutomatically
                 );
 
-            var loopsBetweenTrainFloors =
-                checkOverride
-                && (bool)
-                    AccessTools
-                        .Field(typeof(CharacterData), "loopsBetweenTrainFloors")
-                        .GetValue(data);
+            var loopsBetweenTrainFloors = (bool)AccessTools.Field(typeof(CharacterData), "loopsBetweenTrainFloors").GetValue(data);
             AccessTools
                 .Field(typeof(CharacterData), "loopsBetweenTrainFloors")
                 .SetValue(
@@ -203,12 +180,7 @@ namespace TrainworksReloaded.Base.Character
                         ?? loopsBetweenTrainFloors
                 );
 
-            var attackTeleportsToDefender =
-                checkOverride
-                && (bool)
-                    AccessTools
-                        .Field(typeof(CharacterData), "attackTeleportsToDefender")
-                        .GetValue(data);
+            var attackTeleportsToDefender = (bool)AccessTools.Field(typeof(CharacterData), "attackTeleportsToDefender").GetValue(data);
             AccessTools
                 .Field(typeof(CharacterData), "attackTeleportsToDefender")
                 .SetValue(
@@ -217,10 +189,7 @@ namespace TrainworksReloaded.Base.Character
                         ?? attackTeleportsToDefender
                 );
 
-            var deathSlidesBackwards =
-                checkOverride
-                && (bool)
-                    AccessTools.Field(typeof(CharacterData), "deathSlidesBackwards").GetValue(data);
+            var deathSlidesBackwards = (bool)AccessTools.Field(typeof(CharacterData), "deathSlidesBackwards").GetValue(data);
             AccessTools
                 .Field(typeof(CharacterData), "deathSlidesBackwards")
                 .SetValue(
@@ -229,9 +198,7 @@ namespace TrainworksReloaded.Base.Character
                         ?? deathSlidesBackwards
                 );
 
-            var chosenVariant =
-                checkOverride
-                && (bool)AccessTools.Field(typeof(CharacterData), "chosenVariant").GetValue(data);
+            var chosenVariant = (bool)AccessTools.Field(typeof(CharacterData), "chosenVariant").GetValue(data);
             AccessTools
                 .Field(typeof(CharacterData), "chosenVariant")
                 .SetValue(
@@ -239,19 +206,12 @@ namespace TrainworksReloaded.Base.Character
                     configuration.GetSection("chosen_variant").ParseBool() ?? chosenVariant
                 );
 
-            var isPyreHeart =
-                checkOverride
-                && (bool)AccessTools.Field(typeof(CharacterData), "isPyreHeart").GetValue(data);
+            var isPyreHeart = (bool)AccessTools.Field(typeof(CharacterData), "isPyreHeart").GetValue(data);
             AccessTools
                 .Field(typeof(CharacterData), "isPyreHeart")
                 .SetValue(data, configuration.GetDeprecatedSection("is_pyre", "is_pyre_heart").ParseBool() ?? isPyreHeart);
 
-            var disableInDailyChallenges =
-                checkOverride
-                && (bool)
-                    AccessTools
-                        .Field(typeof(CharacterData), "disableInDailyChallenges")
-                        .GetValue(data);
+            var disableInDailyChallenges = (bool)AccessTools.Field(typeof(CharacterData), "disableInDailyChallenges").GetValue(data);
             AccessTools
                 .Field(typeof(CharacterData), "disableInDailyChallenges")
                 .SetValue(
@@ -260,12 +220,7 @@ namespace TrainworksReloaded.Base.Character
                         ?? disableInDailyChallenges
                 );
 
-            var preventAbilitiesFromEquipment =
-                checkOverride
-                && (bool)
-                    AccessTools
-                        .Field(typeof(CharacterData), "preventAbilitiesFromEquipment")
-                        .GetValue(data);
+            var preventAbilitiesFromEquipment = (bool)AccessTools.Field(typeof(CharacterData), "preventAbilitiesFromEquipment").GetValue(data);
             AccessTools
                 .Field(typeof(CharacterData), "preventAbilitiesFromEquipment")
                 .SetValue(

--- a/TrainworksReloaded.Base/Class/ClassDataPipeline.cs
+++ b/TrainworksReloaded.Base/Class/ClassDataPipeline.cs
@@ -145,8 +145,7 @@ namespace TrainworksReloaded.Base.Class
 
             //handel bool
             var corruptionEnabled =
-                checkOverride
-                && (bool)AccessTools.Field(typeof(ClassData), "corruptionEnabled").GetValue(data);
+                (bool)AccessTools.Field(typeof(ClassData), "corruptionEnabled").GetValue(data);
             AccessTools
                 .Field(typeof(ClassData), "corruptionEnabled")
                 .SetValue(
@@ -155,8 +154,7 @@ namespace TrainworksReloaded.Base.Class
                 );
 
             var isCrew =
-                checkOverride
-                && (bool)AccessTools.Field(typeof(ClassData), "isCrew").GetValue(data);
+                (bool)AccessTools.Field(typeof(ClassData), "isCrew").GetValue(data);
             AccessTools
                 .Field(typeof(ClassData), "isCrew")
                 .SetValue(data, configuration.GetSection("is_crew").ParseBool() ?? isCrew);

--- a/TrainworksReloaded.Base/Room/RoomModifierPipeline.cs
+++ b/TrainworksReloaded.Base/Room/RoomModifierPipeline.cs
@@ -90,6 +90,7 @@ namespace TrainworksReloaded.Base.Room
                 )
             )
             {
+                logger.Log(LogLevel.Error, $"Failed to load room modifer state name {nameClass} in {id} with mod reference {modReference}, Make sure the class inherits from RoomStateModifierBase.");
                 return null;
             }
             AccessTools

--- a/TrainworksReloaded.Base/StatusEffects/StatusEffectDataPipeline.cs
+++ b/TrainworksReloaded.Base/StatusEffects/StatusEffectDataPipeline.cs
@@ -74,7 +74,10 @@ namespace TrainworksReloaded.Base.StatusEffects
 
             var statusEffectStateName = configuration.GetSection("class_name").Value;
             if (statusEffectStateName == null)
+            {
+                logger.Log(LogLevel.Error, $"Missing class_name parameter for status effect id {id}.");
                 return null;
+            }
 
             // Because the statusId is coupled with the class, only search the Assembly defining the status effect.
             var assembly = atlas.PluginDefinitions[key].Assembly;
@@ -83,6 +86,7 @@ namespace TrainworksReloaded.Base.StatusEffects
                 out string? fullyQualifiedName)
             )
             {
+                logger.Log(LogLevel.Error, $"Failed to load status effect state name {statusEffectStateName} in {id}, Make sure the class inherits from StatusEffectState.");
                 return null;
             }
             AccessTools.Field(typeof(StatusEffectData), "statusEffectStateName").SetValue(data, fullyQualifiedName);

--- a/TrainworksReloaded.Base/Trait/CardTraitDataPipeline.cs
+++ b/TrainworksReloaded.Base/Trait/CardTraitDataPipeline.cs
@@ -85,7 +85,7 @@ namespace TrainworksReloaded.Base.Trait
                 )
             )
             {
-                logger.Log(LogLevel.Error, $"Failed to load effect state name {traitStateName} in {name} with mod reference {modReference}, Make sure the class inherits from CardTraitState");
+                logger.Log(LogLevel.Error, $"Failed to load trait state name {traitStateName} in {name} with mod reference {modReference}, Make sure the class inherits from CardTraitState");
                 return null;
             }
             AccessTools

--- a/schemas/definitions/color.json
+++ b/schemas/definitions/color.json
@@ -1,19 +1,24 @@
 {
-    "$id": "https://raw.githubusercontent.com/Monster-Train-2-Modding-Group/Trainworks-Reloaded/refs/heads/main/schemas/definitions/color.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "properties": {
-        "r": {
-            "type": "number"
-        },
-        "g": {
-            "type": "number"
-        },
-        "b": {
-            "type": "number"
-        },
-        "a": {
-            "type": "number"
-        }
+  "$id": "https://raw.githubusercontent.com/Monster-Train-2-Modding-Group/Trainworks-Reloaded/refs/heads/main/schemas/definitions/color.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "r": {
+      "type": "number",
+      "default": 0.0
+    },
+    "g": {
+      "type": "number",
+      "default": 0.0
+    },
+    "b": {
+      "type": "number",
+      "default": 0.0
+    },
+    "a": {
+      "type": "number",
+      "default": 1.0
+
     }
+  }
 }

--- a/schemas/schemas/cards.json
+++ b/schemas/schemas/cards.json
@@ -92,7 +92,7 @@
           },
           "initial_cooldown": {
             "type": "integer",
-            "description": "Initial cooldown value when the card is first added to the deck."
+            "description": "For abilities only. The initial cooldown when the ability is first given to a character."
           },
           "initial_keyboard_target": {
             "$ref": "../definitions/target_assist.json",

--- a/schemas/schemas/characters.json
+++ b/schemas/schemas/characters.json
@@ -120,7 +120,7 @@
           },
           "endless_stats": {
             "type": "object",
-            "description": "Stats for this character in endless mode.",
+            "description": "Stats for this character in endless mode (This is only used by enemy units).",
             "properties": {
               "health": {
                 "type": "integer",

--- a/schemas/schemas/classes.json
+++ b/schemas/schemas/classes.json
@@ -143,11 +143,23 @@
           },
           "ui_color": {
             "$ref": "../definitions/color.json",
-            "description": "Primary color used in the UI for this class."
+            "description": "Primary color used in the UI for this class.",
+            "default": {
+              "r": 1.0,
+              "g": 1.0,
+              "b": 1.0,
+              "a": 1.0
+            }
           },
           "ui_color_dark": {
             "$ref": "../definitions/color.json",
-            "description": "Dark variant of the UI color for this class."
+            "description": "Dark variant of the UI color for this class.",
+            "default": {
+              "r": 0.0,
+              "g": 0.0,
+              "b": 0.0,
+              "a": 1.0
+            }
           },
           "ui_gradient": {
             "type": "array",


### PR DESCRIPTION
## Summary
Additional logging for parsing failures related to specifying Effect classes.
Fix issues with default values when not overriding a Character, Card, Upgrade, or Clan.

## Changes
- For override, any boolean field was changed to default to the current value on the game data. Previously this value was &&'d with the state of the override property which when you aren't overriding defaulted all values of boolean fields to false which was incorrect. Some fields have a default value of true (e.x. `characterData.canAttack`).
- Additional error/warning logs are added to let the modder know if an incorrect class name was given.

## Test JSON
N/A

## Checklist
- no changes to the schema, but some default values are specified.

## Related Issues
N/A
