### PR TITLE
(0.4.2) Revamped Override Support

### DIFF
--- a/Trainworks-Reloaded.sln
+++ b/Trainworks-Reloaded.sln
@@ -90,6 +90,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "definitions", "definitions"
 		schemas\definitions\lore_tooltip_style.json = schemas\definitions\lore_tooltip_style.json
 		schemas\definitions\map_node_type.json = schemas\definitions\map_node_type.json
 		schemas\definitions\map_skip_settings.json = schemas\definitions\map_skip_settings.json
+		schemas\definitions\override_mode.json = schemas\definitions\override_mode.json
 		schemas\definitions\parse_term.json = schemas\definitions\parse_term.json
 		schemas\definitions\persistence.json = schemas\definitions\persistence.json
 		schemas\definitions\rarity.json = schemas\definitions\rarity.json

--- a/TrainworksReloaded.Base/Card/CardDataFinalizer.cs
+++ b/TrainworksReloaded.Base/Card/CardDataFinalizer.cs
@@ -212,7 +212,7 @@ namespace TrainworksReloaded.Base.Card
 
             var cardEffectDatas = data.GetEffects();
             var cardEffectDatasConfig = configuration.GetSection("effects");
-            if (overrideMode != OverrideMode.Replace && cardEffectDatasConfig.Exists())
+            if (overrideMode == OverrideMode.Replace && cardEffectDatasConfig.Exists())
             {
                 cardEffectDatas.Clear();
             }

--- a/TrainworksReloaded.Base/Card/CardDataFinalizer.cs
+++ b/TrainworksReloaded.Base/Card/CardDataFinalizer.cs
@@ -102,7 +102,7 @@ namespace TrainworksReloaded.Base.Card
             {
                 SharedDiscoveryCards.Clear();
             }
-            var SharedDiscoveryCardReferences = configuration
+            var SharedDiscoveryCardReferences = SharedDiscoveryCardsConfig
                 .GetChildren()
                 .Select(x => x.ParseReference())
                 .Where(x => x != null)
@@ -203,9 +203,9 @@ namespace TrainworksReloaded.Base.Card
             foreach (var traitReference in cardTraitReferences)
             {
                 var id = traitReference.ToId(key, TemplateConstants.Trait);
-                if (traitRegister.TryLookupId(id, out var card, out var _))
+                if (traitRegister.TryLookupId(id, out var trait, out var _))
                 {
-                    cardTraitDatas.Add(card);
+                    cardTraitDatas.Add(trait);
                 }
             }
             AccessTools.Field(typeof(CardData), "traits").SetValue(data, cardTraitDatas);

--- a/TrainworksReloaded.Base/CardUpgrade/CardUpgradeFinalizer.cs
+++ b/TrainworksReloaded.Base/CardUpgrade/CardUpgradeFinalizer.cs
@@ -169,7 +169,7 @@ namespace TrainworksReloaded.Base.CardUpgrade
             AccessTools.Field(typeof(CardUpgradeData), "roomModifierUpgrades").SetValue(data, roomModifierUpgrades);
 
             //status
-            var statusEffectUpgrades = data.GetStatusEffectUpgrades();
+            var statusEffectUpgrades = data.GetStatusEffectUpgrades() ?? [];
             var statusEffectUpgradesConfig = configuration.GetSection("status_effect_upgrades");
             if (overrideMode == OverrideMode.Replace && statusEffectUpgradesConfig.Exists())
             {

--- a/TrainworksReloaded.Base/CardUpgrade/CardUpgradePipeline.cs
+++ b/TrainworksReloaded.Base/CardUpgrade/CardUpgradePipeline.cs
@@ -7,6 +7,7 @@ using SimpleInjector;
 using TrainworksReloaded.Base.Card;
 using TrainworksReloaded.Base.Extensions;
 using TrainworksReloaded.Base.Localization;
+using TrainworksReloaded.Core.Enum;
 using TrainworksReloaded.Core.Extensions;
 using TrainworksReloaded.Core.Impl;
 using TrainworksReloaded.Core.Interfaces;
@@ -87,10 +88,10 @@ namespace TrainworksReloaded.Base.CardUpgrade
             var titleKey = $"CardUpgrade_titleKey-{name}";
             var descriptionKey = $"CardUpgrade_descriptionKey-{name}";
             var notificationKey = $"CardUpgrade_notificationKey-{name}";
-            var checkOverride = configuration.GetSection("override").ParseBool() ?? false;
+            var overrideMode = configuration.GetSection("override").ParseOverrideMode();
 
             string guid;
-            if (checkOverride && service.TryLookupName(id, out CardUpgradeData? data, out var _))
+            if (overrideMode.IsOverriding() && service.TryLookupName(id, out CardUpgradeData? data, out var _))
             {
                 logger.Log(LogLevel.Info, $"Overriding Upgrade {id}...");
                 titleKey = data.GetUpgradeTitleKey();
@@ -224,23 +225,17 @@ namespace TrainworksReloaded.Base.CardUpgrade
                 );
 
             //int
-            var bonusDamage = checkOverride
-                ? (int)AccessTools.Field(typeof(CardUpgradeData), "bonusDamage").GetValue(data)
-                : 0;
+            var bonusDamage = (int)AccessTools.Field(typeof(CardUpgradeData), "bonusDamage").GetValue(data);
             AccessTools
                 .Field(typeof(CardUpgradeData), "bonusDamage")
                 .SetValue(data, configuration.GetSection("bonus_damage").ParseInt() ?? bonusDamage);
 
-            var bonusHP = checkOverride
-                ? (int)AccessTools.Field(typeof(CardUpgradeData), "bonusHP").GetValue(data)
-                : 0;
+            var bonusHP = (int)AccessTools.Field(typeof(CardUpgradeData), "bonusHP").GetValue(data);
             AccessTools
                 .Field(typeof(CardUpgradeData), "bonusHP")
                 .SetValue(data, configuration.GetSection("bonus_hp").ParseInt() ?? bonusHP);
 
-            var costReduction = checkOverride
-                ? (int)AccessTools.Field(typeof(CardUpgradeData), "costReduction").GetValue(data)
-                : 0;
+            var costReduction = (int)AccessTools.Field(typeof(CardUpgradeData), "costReduction").GetValue(data);
             AccessTools
                 .Field(typeof(CardUpgradeData), "costReduction")
                 .SetValue(
@@ -248,9 +243,7 @@ namespace TrainworksReloaded.Base.CardUpgrade
                     configuration.GetSection("cost_reduction").ParseInt() ?? costReduction
                 );
 
-            var xCostReduction = checkOverride
-                ? (int)AccessTools.Field(typeof(CardUpgradeData), "xCostReduction").GetValue(data)
-                : 0;
+            var xCostReduction = (int)AccessTools.Field(typeof(CardUpgradeData), "xCostReduction").GetValue(data);
             AccessTools
                 .Field(typeof(CardUpgradeData), "xCostReduction")
                 .SetValue(
@@ -258,23 +251,17 @@ namespace TrainworksReloaded.Base.CardUpgrade
                     configuration.GetSection("x_cost_reduction").ParseInt() ?? xCostReduction
                 );
 
-            var bonusHeal = checkOverride
-                ? (int)AccessTools.Field(typeof(CardUpgradeData), "bonusHeal").GetValue(data)
-                : 0;
+            var bonusHeal = (int)AccessTools.Field(typeof(CardUpgradeData), "bonusHeal").GetValue(data);
             AccessTools
                 .Field(typeof(CardUpgradeData), "bonusHeal")
                 .SetValue(data, configuration.GetSection("bonus_heal").ParseInt() ?? bonusHeal);
 
-            var bonusSize = checkOverride
-                ? (int)AccessTools.Field(typeof(CardUpgradeData), "bonusSize").GetValue(data)
-                : 0;
+            var bonusSize = (int)AccessTools.Field(typeof(CardUpgradeData), "bonusSize").GetValue(data);
             AccessTools
                 .Field(typeof(CardUpgradeData), "bonusSize")
                 .SetValue(data, configuration.GetSection("bonus_size").ParseInt() ?? bonusSize);
 
-            var bonusEquipment = checkOverride
-                ? (int)AccessTools.Field(typeof(CardUpgradeData), "bonusEquipment").GetValue(data)
-                : 0;
+            var bonusEquipment = (int)AccessTools.Field(typeof(CardUpgradeData), "bonusEquipment").GetValue(data);
             AccessTools
                 .Field(typeof(CardUpgradeData), "bonusEquipment")
                 .SetValue(
@@ -282,9 +269,7 @@ namespace TrainworksReloaded.Base.CardUpgrade
                     configuration.GetSection("bonus_equipment").ParseInt() ?? bonusEquipment
                 );
 
-            var excludeFromClones = checkOverride
-                ? (bool)AccessTools.Field(typeof(CardUpgradeData), "excludeFromClones").GetValue(data)
-                : false;
+            var excludeFromClones = (bool)AccessTools.Field(typeof(CardUpgradeData), "excludeFromClones").GetValue(data);
             AccessTools
                 .Field(typeof(CardUpgradeData), "excludeFromClones")
                 .SetValue(
@@ -293,19 +278,17 @@ namespace TrainworksReloaded.Base.CardUpgrade
                 );
 
             //List<String>
-            var removeTraitUpgrades =
-                (List<string>)
-                    AccessTools.Field(typeof(CardUpgradeData), "removeTraitUpgrades").GetValue(data)
-                ?? [];
-            var upgradeReferences = configuration.GetSection("remove_trait_upgrades")
+            var removeTraitUpgrades = data.GetRemoveTraitUpgrades();
+            var removeTraitUpgradeConfig = configuration.GetSection("remove_trait_upgrades");
+            if (overrideMode == OverrideMode.Replace && removeTraitUpgradeConfig.Exists())
+            {
+                removeTraitUpgrades.Clear();
+            }    
+            var upgradeReferences = removeTraitUpgradeConfig 
                 .GetChildren()
                 .Select(x => x.ParseReference())
                 .Where(x => x != null)
                 .Cast<ReferencedObject>();
-            if (upgradeReferences.Count() > 0)
-            {
-                removeTraitUpgrades.Clear();
-            }
             foreach (var reference in upgradeReferences)
             {
                 var traitStateName = reference.id;
@@ -327,9 +310,10 @@ namespace TrainworksReloaded.Base.CardUpgrade
                 .Field(typeof(CardUpgradeData), "removeTraitUpgrades")
                 .SetValue(data, removeTraitUpgrades);
 
-            if (!checkOverride)
+            var modded = overrideMode.IsNewContent() || overrideMode.IsCloning();
+            if (modded)
                 service.Register(name, data);
-            return new CardUpgradeDefinition(key, data, configuration, checkOverride);
+            return new CardUpgradeDefinition(key, data, configuration, modded);
         }
     }
 }

--- a/TrainworksReloaded.Base/CardUpgrade/CardUpgradePipeline.cs
+++ b/TrainworksReloaded.Base/CardUpgrade/CardUpgradePipeline.cs
@@ -278,7 +278,7 @@ namespace TrainworksReloaded.Base.CardUpgrade
                 );
 
             //List<String>
-            var removeTraitUpgrades = data.GetRemoveTraitUpgrades();
+            var removeTraitUpgrades = data.GetRemoveTraitUpgrades() ?? [];
             var removeTraitUpgradeConfig = configuration.GetSection("remove_trait_upgrades");
             if (overrideMode == OverrideMode.Replace && removeTraitUpgradeConfig.Exists())
             {

--- a/TrainworksReloaded.Base/Class/ClassDataPipeline.cs
+++ b/TrainworksReloaded.Base/Class/ClassDataPipeline.cs
@@ -8,6 +8,7 @@ using SimpleInjector;
 using TrainworksReloaded.Base.Class;
 using TrainworksReloaded.Base.Extensions;
 using TrainworksReloaded.Base.Localization;
+using TrainworksReloaded.Core.Enum;
 using TrainworksReloaded.Core.Extensions;
 using TrainworksReloaded.Core.Impl;
 using TrainworksReloaded.Core.Interfaces;
@@ -87,10 +88,10 @@ namespace TrainworksReloaded.Base.Class
             var titleKey = $"ClassData_titleKey-{name}";
             var descriptionKey = $"ClassData_descriptionKey-{name}";
             var subclassDescriptionKey = $"ClassData_subclassDescriptionKey-{name}";
-            var checkOverride = configuration.GetSection("override").ParseBool() ?? false;
+            var overrideMode = configuration.GetSection("override").ParseOverrideMode();
 
             string guid;
-            if (checkOverride && service.TryLookupName(id, out ClassData? data, out var _))
+            if (overrideMode.IsOverriding() && service.TryLookupName(id, out ClassData? data, out var _))
             {
                 logger.Log(LogLevel.Info, $"Overriding Clan {id}...");
                 titleKey = data.GetTitleKey();
@@ -144,8 +145,7 @@ namespace TrainworksReloaded.Base.Class
             }
 
             //handel bool
-            var corruptionEnabled =
-                (bool)AccessTools.Field(typeof(ClassData), "corruptionEnabled").GetValue(data);
+            var corruptionEnabled = data.GetCorruptionEnabled();
             AccessTools
                 .Field(typeof(ClassData), "corruptionEnabled")
                 .SetValue(
@@ -153,16 +153,13 @@ namespace TrainworksReloaded.Base.Class
                     configuration.GetSection("corruption_enabled").ParseBool() ?? corruptionEnabled
                 );
 
-            var isCrew =
-                (bool)AccessTools.Field(typeof(ClassData), "isCrew").GetValue(data);
+            var isCrew = data.IsCrew();
             AccessTools
                 .Field(typeof(ClassData), "isCrew")
                 .SetValue(data, configuration.GetSection("is_crew").ParseBool() ?? isCrew);
 
             //string
-            var clanSelectSfxCue = checkOverride
-                ? (string)AccessTools.Field(typeof(ClassData), "clanSelectSfxCue").GetValue(data)
-                : "";
+            var clanSelectSfxCue = data.GetClanSelectSfxCue() ?? "";
             AccessTools
                 .Field(typeof(ClassData), "clanSelectSfxCue")
                 .SetValue(
@@ -171,17 +168,13 @@ namespace TrainworksReloaded.Base.Class
                 );
 
             //handle color
-            var uiColor = checkOverride
-                ? (Color)AccessTools.Field(typeof(ClassData), "uiColor").GetValue(data)
-                : Color.white;
+            var uiColor = overrideMode.IsNewContent() ? Color.white : data.GetUIColor();
             AccessTools
                 .Field(typeof(ClassData), "uiColor")
                 .SetValue(data, configuration.GetSection("ui_color").ParseColor() ?? uiColor);
 
             //handle color
-            var uiColorDark = checkOverride
-                ? (Color)AccessTools.Field(typeof(ClassData), "uiColorDark").GetValue(data)
-                : Color.black;
+            var uiColorDark = overrideMode.IsNewContent() ? Color.black : data.GetUIColorDark();
             AccessTools
                 .Field(typeof(ClassData), "uiColorDark")
                 .SetValue(
@@ -190,12 +183,11 @@ namespace TrainworksReloaded.Base.Class
                 );
 
             //parse gradient
-            var gradient = checkOverride
-                ? (Gradient)AccessTools.Field(typeof(ClassData), "uiColorGradient").GetValue(data)
-                : new Gradient();
-            var gradientKeysConfig = configuration.GetSection("ui_gradient").GetChildren();
+            var gradient = overrideMode.IsNewContent() ? new Gradient() :
+                (Gradient)AccessTools.Field(typeof(ClassData), "uiColorGradient").GetValue(data);
+            var gradientKeysConfig = configuration.GetSection("ui_gradient");
             List<GradientColorKey> gradientColorKeys = [];
-            foreach (var gradientKeyConfig in gradientKeysConfig)
+            foreach (var gradientKeyConfig in gradientKeysConfig.GetChildren())
             {
                 var time = gradientKeyConfig.GetSection("time").ParseFloat();
                 var color = gradientKeyConfig.GetSection("color").ParseColor() ?? Color.white;
@@ -212,13 +204,13 @@ namespace TrainworksReloaded.Base.Class
             var classUnlockPreviewTexts =
                 (List<string>)
                     AccessTools.Field(typeof(ClassData), "classUnlockPreviewTexts").GetValue(data);
-            var previews = configuration.GetDeprecatedSection("class_preview_texts", "class_unlock_preview_texts").GetChildren();
-            if (previews.Count() > 0)
+            var previews = configuration.GetDeprecatedSection("class_preview_texts", "class_unlock_preview_texts");
+            if (overrideMode == OverrideMode.Replace && previews.Exists())
             {
                 classUnlockPreviewTexts.Clear();
             }
             int i = 0;
-            foreach (var preview in previews)
+            foreach (var preview in previews.GetChildren())
             {
                 var val = preview.ParseLocalizationTerm();
                 if (val == null)
@@ -232,9 +224,7 @@ namespace TrainworksReloaded.Base.Class
             }
 
             //card style
-            var cardStyle = checkOverride
-                ? (ClassCardStyle)AccessTools.Field(typeof(ClassData), "cardStyle").GetValue(data)
-                : ClassCardStyle.None;
+            var cardStyle = data.GetCardStyle();
             AccessTools
                 .Field(typeof(ClassData), "cardStyle")
                 .SetValue(
@@ -243,10 +233,11 @@ namespace TrainworksReloaded.Base.Class
                 );
 
             //register before filling in data using
-            if (!checkOverride)
+            var modded = overrideMode.IsCloning() || overrideMode.IsNewContent();
+            if (modded)
                 service.Register(name, data);
 
-            return new ClassDataDefinition(key, data, configuration, checkOverride);
+            return new ClassDataDefinition(key, data, configuration, !modded);
         }
     }
 }

--- a/TrainworksReloaded.Base/Extensions/ParseEnumExtensions.cs
+++ b/TrainworksReloaded.Base/Extensions/ParseEnumExtensions.cs
@@ -4,6 +4,7 @@ using ShinyShoe;
 using System;
 using System.Linq;
 using TrainworksReloaded.Base.Localization;
+using TrainworksReloaded.Core.Enum;
 using TrainworksReloaded.Core.Extensions;
 using UnityEngine;
 using static BossState;
@@ -19,6 +20,24 @@ namespace TrainworksReloaded.Base.Extensions
 {
     public static class ParseEnumExtensions
     {
+        public static OverrideMode ParseOverrideMode(this IConfigurationSection section)
+        {
+            var val = section.Value;
+            if (string.IsNullOrEmpty(val))
+            {
+                return OverrideMode.New;
+            }
+            return val.ToLower() switch
+            {
+                "false" => OverrideMode.New,
+                "true" => OverrideMode.Replace,
+                "replace" => OverrideMode.Replace,
+                "append" => OverrideMode.Append,
+                "clone" => OverrideMode.Clone,
+                _ => OverrideMode.New
+            };
+        }
+
         public static MapNodeData.SkipCheckSettings? ParseSkipSettings(
             this IConfigurationSection section
         )

--- a/TrainworksReloaded.Base/Extensions/ParseReferenceExtensions.cs
+++ b/TrainworksReloaded.Base/Extensions/ParseReferenceExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Configuration;
+using ShinyShoe.Logging;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -30,9 +31,10 @@ namespace TrainworksReloaded.Base.Extensions
         {
             string? id = section.Value ?? section.GetSection("id").Value;
             string? mod_reference = section.GetSection("mod_reference").Value;
-            if (id == null || id == "null")
+
+            if (id.IsNullOrEmpty() || id == "null")
                 return null;
-            return new ReferencedObject(id, mod_reference);
+            return new ReferencedObject(id!, mod_reference);
         }
     }
 }

--- a/TrainworksReloaded.Base/Extensions/ParseReferenceExtensions.cs
+++ b/TrainworksReloaded.Base/Extensions/ParseReferenceExtensions.cs
@@ -30,7 +30,7 @@ namespace TrainworksReloaded.Base.Extensions
         {
             string? id = section.Value ?? section.GetSection("id").Value;
             string? mod_reference = section.GetSection("mod_reference").Value;
-            if (id == null)
+            if (id == null || id == "null")
                 return null;
             return new ReferencedObject(id, mod_reference);
         }

--- a/TrainworksReloaded.Base/Extensions/RegisterExtensions.cs
+++ b/TrainworksReloaded.Base/Extensions/RegisterExtensions.cs
@@ -27,7 +27,7 @@ namespace TrainworksReloaded.Base.Extensions
             bool ret = register.TryLookupIdentifier(name, RegisterIdentifierType.ReadableID, out lookup, out IsModded);
             if (!ret)
             {
-                Logger.LogWarning($"Could not find identifier in {typeof(T).Name} Register with id (name) {name}. Some data may not be present on {typeof(T).Name}");
+                Logger.LogWarning($"Could not find identifier in {register.GetType().Name} with id (name) {name}. Some data may not be present on {typeof(T).Name}");
                 Logger.LogDebug($"{Environment.StackTrace}");
             }
             return ret;
@@ -49,7 +49,7 @@ namespace TrainworksReloaded.Base.Extensions
             bool ret = register.TryLookupIdentifier(id, RegisterIdentifierType.GUID, out lookup, out IsModded);
             if (!ret)
             {
-                Logger.LogWarning($"Could not find identifier in {typeof(T).Name} Register with id (guid) {id}. Some data may not be present on {typeof(T).Name}");
+                Logger.LogWarning($"Could not find identifier in {register.GetType().Name} with id (guid) {id}. Some data may not be present on {typeof(T).Name}");
                 Logger.LogDebug($"{Environment.StackTrace}");
             }
             return ret;

--- a/TrainworksReloaded.Base/Relic/EnhancerPoolRegister.cs
+++ b/TrainworksReloaded.Base/Relic/EnhancerPoolRegister.cs
@@ -65,7 +65,13 @@ namespace TrainworksReloaded.Base.Relic
 
         public static EnhancerPool? GetVanillaEnhancerPool(AllGameData allGameData, string poolName)
         {
-            if (poolName == "DraftUpgradePool")
+            if (poolName == "MalickaDraftUpgradePool")
+            {
+                PyreArtifactData? malickaPyre = allGameData.FindPyreArtifactData("68a9b977-3407-4128-bf35-245fd92f8e2b");
+                var effect = malickaPyre?.GetFirstRelicEffectData<RelicEffectAddStartingUpgradeToCardDrafts>();
+                return effect?.GetParamEnhancerPool();
+            }    
+            else if (poolName == "DraftUpgradePool")
             {
                 CollectableRelicData? capriciousReflection = allGameData.FindCollectableRelicData("9e0e5d4e-6d16-43f1-8cd4-cc4c2b431afd");
                 var effect = capriciousReflection?.GetFirstRelicEffectData<RelicEffectAddStartingUpgradeToCardDrafts>();

--- a/TrainworksReloaded.Base/Relic/RelicEffectDataFinalizer.cs
+++ b/TrainworksReloaded.Base/Relic/RelicEffectDataFinalizer.cs
@@ -96,7 +96,7 @@ namespace TrainworksReloaded.Base.Relic
             var data = definition.Data;
             var key = definition.Key;
 
-            logger.Log(LogLevel.Debug, $"Finalizing RelicEffect {key}... ");
+            logger.Log(LogLevel.Debug, $"Finalizing RelicEffect {key} {definition.Id}... ");
 
             // Handle status effects
             var statusEffects = new List<StatusEffectStackData>();

--- a/TrainworksReloaded.Core/Enum/OverrideMode.cs
+++ b/TrainworksReloaded.Core/Enum/OverrideMode.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TrainworksReloaded.Core.Enum
+{
+    public enum OverrideMode
+    {
+        New,
+        Replace,
+        Append,
+        Clone
+    }
+
+    public static class OverrideModeExtensions
+    {
+        public static bool IsNewContent(this OverrideMode overrideMode)
+        {
+            return overrideMode == OverrideMode.New;
+        }
+
+        public static bool IsOverriding(this OverrideMode overrideMode)
+        {
+            return overrideMode == OverrideMode.Replace || overrideMode == OverrideMode.Append;
+        }
+
+        public static bool IsCloning(this OverrideMode overrideMode)
+        {
+            return overrideMode == OverrideMode.Clone;
+        }
+    }
+}

--- a/schemas/definitions/card_target_mode.json
+++ b/schemas/definitions/card_target_mode.json
@@ -1,31 +1,27 @@
 {
-    "$id": "https://raw.githubusercontent.com/Monster-Train-2-Modding-Group/Trainworks-Reloaded/refs/heads/main/schemas/definitions/card_target_mode.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "string",
-    "description": "Target modes for cards. Multiple modes can be combined using the '|' character.",
-    "examples": [
-        "all",
-        "single",
-        "targetless",
-        "other",
-        "none",
-        "all|single",
-        "single|targetless",
-        "all|single|targetless"
-    ],
-    "oneOf": [{
-            "enum": [
-                "all",
-                "single",
-                "targetless",
-                "other",
-                "none"
-            ]
-        },
-        {
-            "type": "string",
-            "pattern": "^(all|single|targetless|other|none)(\\|(all|single|targetless|other|none))*$",
-            "description": "Multiple target modes combined with '|' character"
-        }
-    ]
+  "$id": "https://raw.githubusercontent.com/Monster-Train-2-Modding-Group/Trainworks-Reloaded/refs/heads/main/schemas/definitions/card_target_mode.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "string",
+  "description": "Target modes for cards. These aren't the same as TargetMode. The CardTargetMode is determined by the first effects' target mode.",
+  "examples": [
+    [ "all" ],
+    [ "single" ],
+    [ "single", "targetless" ],
+  ],
+  "oneOf": [
+    {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "all",
+          "single",
+          "targetless",
+          "other",
+          "none"
+        ]
+      }
+    }
+  ]
 }

--- a/schemas/definitions/card_target_mode.json
+++ b/schemas/definitions/card_target_mode.json
@@ -2,11 +2,11 @@
   "$id": "https://raw.githubusercontent.com/Monster-Train-2-Modding-Group/Trainworks-Reloaded/refs/heads/main/schemas/definitions/card_target_mode.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "string",
-  "description": "Target modes for cards. These aren't the same as TargetMode. The CardTargetMode is determined by the first effects' target mode.",
+  "description": "Target modes for cards. The CardTargetMode is determined by the first effects' target mode.",
   "examples": [
     [ "all" ],
     [ "single" ],
-    [ "single", "targetless" ],
+    [ "single", "targetless" ]
   ],
   "oneOf": [
     {

--- a/schemas/definitions/enhancer_pool.json
+++ b/schemas/definitions/enhancer_pool.json
@@ -11,6 +11,7 @@
         "SpellUpgradePoolCommon",
         "SpellUpgradePoolRare",
         "DraftUpgradePool",
+        "MalickaDraftUpgradePool",
         null
       ]
     },

--- a/schemas/definitions/override_mode.json
+++ b/schemas/definitions/override_mode.json
@@ -1,0 +1,16 @@
+{
+  "$id": "https://raw.githubusercontent.com/Monster-Train-2-Modding-Group/Trainworks-Reloaded/refs/heads/main/schemas/definitions/override_mode.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "anyOf": [
+    {
+      "type": "string",
+      "enum": [
+        "replace",
+        "append"
+      ]
+    },
+    {
+      "type": "boolean"
+    }
+  ]
+}

--- a/schemas/schemas/card_triggers.json
+++ b/schemas/schemas/card_triggers.json
@@ -40,7 +40,7 @@
                 "description": "Integer parameter for the trigger effect."
               },
               "param_upgrade": {
-                "$ref": "../defintions/card_upgrade.json",
+                "$ref": "../definitions/card_upgrade.json",
                 "description": "Reference to an upgrade that should be applied."
               },
               "persistence_mode": {

--- a/schemas/schemas/cards.json
+++ b/schemas/schemas/cards.json
@@ -103,7 +103,7 @@
             "type": "array",
             "description": "List of upgrades that are applied when the card is first added to the deck.",
             "items": {
-              "$ref": "../defintions/card_upgrade.json",
+              "$ref": "../definitions/card_upgrade.json",
               "description": "Reference to an upgrade's unique identifier."
             }
           },
@@ -113,7 +113,7 @@
             "default": false
           },
           "linked_mastery_card": {
-            "$ref": "../defintions/card.json",
+            "$ref": "../definitions/card.json",
             "description": "Used when a card has different variations (Think Blazing Bolts from MT1) the masteries are all linked to the original variation."
           },
           "lore_tooltips": {
@@ -129,7 +129,7 @@
             "description": "Localized text for this card's name."
           },
           "off_cooldown_vfx": {
-            "$ref": "../defintions/vfx.json",
+            "$ref": "../definitions/vfx.json",
             "description": "Vfx used when card is off cooldown."
           },
           "override": {
@@ -158,7 +158,7 @@
             "type": "array",
             "description": "List of cards that are discovered together with this card.",
             "items": {
-              "$ref": "../defintions/card.json",
+              "$ref": "../definitions/card.json",
               "description": "Reference to a card's id"
             }
           },
@@ -166,12 +166,12 @@
             "type": "array",
             "description": "List of cards that share mastery progress with this card.",
             "items": {
-              "$ref": "../defintions/card.json",
+              "$ref": "../definitions/card.json",
               "description": "Reference to a card's id"
             }
           },
           "special_edge_vfx": {
-            "$ref": "../defintions/vfx.json",
+            "$ref": "../definitions/vfx.json",
             "description": "VFX used on the edge of the card."
           },
           "targetless": {
@@ -188,7 +188,7 @@
             "type": "array",
             "description": "List of traits this card has.",
             "items": {
-              "$ref": "../defintions/reference.json",
+              "$ref": "../definitions/reference.json",
               "description": "Reference to a trait's unique identifier."
             }
           },
@@ -196,7 +196,7 @@
             "type": "array",
             "description": "List of triggers this card has.",
             "items": {
-              "$ref": "../defintions/reference.json",
+              "$ref": "../definitions/reference.json",
               "description": "Reference to a trigger's unique identifier."
             }
           },

--- a/schemas/schemas/effects.json
+++ b/schemas/schemas/effects.json
@@ -25,11 +25,11 @@
             "default": "none"
           },
           "applied_to_self_vfx": {
-            "$ref": "../defintions/vfx.json",
+            "$ref": "../definitions/vfx.json",
             "description": "Reference to VFX to use when applying the card effect to self."
           },
           "applied_vfx": {
-            "$ref": "../defintions/vfx.json",
+            "$ref": "../definitions/vfx.json",
             "description": "Reference to VFX to use when applying the card effect."
           },
           "copy_modifiers_from_source": {

--- a/schemas/schemas/traits.json
+++ b/schemas/schemas/traits.json
@@ -34,7 +34,7 @@
             "description": "Unique identifier for this trait."
           },
           "name": {
-            "$ref": "../defintions/card_trait.json",
+            "$ref": "../definitions/card_trait.json",
             "description": "The TraitStateName, this should be the name of a Class inheriting from CardTraitBase. This can be a class from the base game, a class from your Plugin (preceded by an @), or an object with id and mod_reference to refer to a class in someone else's mod."
           },
           "param_bool": {


### PR DESCRIPTION
## Summary
Revamped Override support. And a few bugfixes.

## Changes
- Improved Override Support
- Fixed schema $ref's point to an incorrect directory
- Fixed parsing of fields set to null
- Fixed some log messages

## Test JSON
N/A

## Checklist
Any fields that had override now support the values "replace" and "append". True and false still works.
Some $refs referred to an incorrect "defintions" directory.
MalickaDraftUpgradePool added to vanilla enhancer pools

## Related Issues
Fixes #72 
