### PR TITLE
Relic Effect Conditions

### DIFF
--- a/Trainworks-Reloaded.sln
+++ b/Trainworks-Reloaded.sln
@@ -41,6 +41,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "schemas", "schemas", "{7F34
 		schemas\schemas\map_nodes.json = schemas\schemas\map_nodes.json
 		schemas\schemas\relics.json = schemas\schemas\relics.json
 		schemas\schemas\relic_effects.json = schemas\schemas\relic_effects.json
+		schemas\schemas\relic_effect_conditions.json = schemas\schemas\relic_effect_conditions.json
 		schemas\schemas\relic_pools.json = schemas\schemas\relic_pools.json
 		schemas\schemas\replacement_texts.json = schemas\schemas\replacement_texts.json
 		schemas\schemas\rewards.json = schemas\schemas\rewards.json

--- a/TrainworksReloaded.Base/CardUpgrade/CardUpgradeMaskPipeline.cs
+++ b/TrainworksReloaded.Base/CardUpgrade/CardUpgradeMaskPipeline.cs
@@ -137,15 +137,7 @@ namespace TrainworksReloaded.Base.CardUpgrade
                 .Cast<CardType>().ToList();
             AccessTools.Field(typeof(CardUpgradeMaskData), "additionalCardTypes").SetValue(data, cardTypes);
 
-            CardTargetMode targetMode = CardTargetMode.All;
-            foreach (var child in configuration.GetSection("card_target_mode").GetChildren())
-            {
-                var parsedMode = child.ParseCardTargetMode();
-                if (parsedMode != null)
-                {
-                    targetMode |= parsedMode.Value;
-                }
-            }
+            CardTargetMode targetMode = configuration.GetSection("card_target_mode").ParseCardTargetMode() ?? CardTargetMode.All;
             AccessTools.Field(typeof(CardUpgradeMaskData), "cardTargetMode").SetValue(data, targetMode);
 
             var raritesRequired = configuration

--- a/TrainworksReloaded.Base/Extensions/ParseEnumExtensions.cs
+++ b/TrainworksReloaded.Base/Extensions/ParseEnumExtensions.cs
@@ -15,6 +15,7 @@ using static CharacterUI;
 using static MetagameSaveData;
 using static TooltipDesigner;
 using static VfxAtLoc;
+using static RelicEffectCondition;
 
 namespace TrainworksReloaded.Base.Extensions
 {
@@ -293,7 +294,19 @@ namespace TrainworksReloaded.Base.Extensions
             var val = section.Value;
             if (string.IsNullOrEmpty(val))
             {
-                return null;
+                if (!section.GetChildren().Any())
+                {
+                    return null;
+                }
+                CardTargetMode ret = CardTargetMode.All;
+                foreach (var child in section.GetChildren())
+                {
+                    if (child.Value != null)
+                    {
+                        ret |= (ParseCardTargetMode(section) ?? CardTargetMode.All); 
+                    }
+                }
+                return ret;
             }
             
             val = val.ToLower();
@@ -1116,6 +1129,52 @@ namespace TrainworksReloaded.Base.Extensions
                 return defaultValue;
             }
             return value.Value;
+        }
+
+        public static Comparator? ParseComparator(this IConfigurationSection section)
+        {
+            var val = section.Value;
+            if (string.IsNullOrEmpty(val))
+            {
+                if (!section.GetChildren().Any())
+                {
+                    return null;
+                }
+                Comparator ret = 0;
+                foreach (var child in section.GetChildren())
+                {
+                    if (child.Value != null)
+                    {
+                        ret |= (ParseComparator(section) ?? 0);
+                    }
+                }
+                return ret;
+            }
+
+            val = val.ToLower();
+            var values = val.Split('|', StringSplitOptions.RemoveEmptyEntries)
+                           .Select(v => v.Trim())
+                           .ToList();
+
+            Comparator result = 0;
+            foreach (var value in values)
+            {
+                Comparator? flag = value switch
+                {
+                    "less_than" => Comparator.LessThan,
+                    "greater_than" => Comparator.GreaterThan,
+                    "equal" => Comparator.Equal,
+                    _ => null
+                };
+
+                if (flag == null)
+                {
+                    return null;
+                }
+
+                result |= flag.Value;
+            }
+            return result;
         }
     }
 }

--- a/TrainworksReloaded.Base/Extensions/ParseEnumExtensions.cs
+++ b/TrainworksReloaded.Base/Extensions/ParseEnumExtensions.cs
@@ -289,6 +289,21 @@ namespace TrainworksReloaded.Base.Extensions
             };
         }
 
+        private static CardTargetMode? DoParseCardTargetMode(string? val)
+        {
+            if (val == null)
+                return null;
+            return val.ToLower() switch
+            {
+                "none" => CardTargetMode.NONE,
+                "all" => CardTargetMode.All,
+                "single" => CardTargetMode.SingleTarget,
+                "targetless" => CardTargetMode.Targetless,
+                "other" => CardTargetMode.Other,
+                _ => null
+            };
+        }
+
         public static CardTargetMode? ParseCardTargetMode(this IConfigurationSection section)
         {
             var val = section.Value;
@@ -301,40 +316,30 @@ namespace TrainworksReloaded.Base.Extensions
                 CardTargetMode ret = CardTargetMode.All;
                 foreach (var child in section.GetChildren())
                 {
-                    if (child.Value != null)
-                    {
-                        ret |= (ParseCardTargetMode(section) ?? CardTargetMode.All); 
-                    }
+                    var flag = DoParseCardTargetMode(child.Value);
+                    if (flag == null)
+                        return null;
+                    ret |= flag.Value;
                 }
                 return ret;
             }
-            
-            val = val.ToLower();
-            var values = val.Split('|', StringSplitOptions.RemoveEmptyEntries)
-                           .Select(v => v.Trim())
-                           .ToList();
-
-            CardTargetMode result = CardTargetMode.All;
-            foreach (var value in values)
+            else
             {
-                CardTargetMode? flag = value switch
-                {
-                    "none" => CardTargetMode.NONE,
-                    "all" => CardTargetMode.All,
-                    "single" => CardTargetMode.SingleTarget,
-                    "targetless" => CardTargetMode.Targetless,
-                    "other" => CardTargetMode.Other,
-                    _ => null
-                };
+                var values = val.Split('|', StringSplitOptions.RemoveEmptyEntries)
+                               .Select(v => v.Trim())
+                               .ToList();
 
-                if (flag == null)
+                CardTargetMode result = CardTargetMode.All;
+                foreach (var value in values)
                 {
-                    return null;
+                    var flag = DoParseCardTargetMode(value);
+                    if (flag == null)
+                        return null;
+                    result |= flag.Value;
                 }
-
-                result |= flag.Value;
+                return result;
             }
-            return result;
+
         }
 
         public static object ParseCompareOperator(this IConfigurationSection section, string defaultVal = "and")
@@ -1131,6 +1136,19 @@ namespace TrainworksReloaded.Base.Extensions
             return value.Value;
         }
 
+        private static Comparator? DoParseComparator(string? val)
+        {
+            if (string.IsNullOrEmpty(val))
+                return null;
+            return val.ToLower() switch
+            {
+                "less_than" => Comparator.LessThan,
+                "greater_than" => Comparator.GreaterThan,
+                "equal" => Comparator.Equal,
+                _ => null
+            };
+        }
+
         public static Comparator? ParseComparator(this IConfigurationSection section)
         {
             var val = section.Value;
@@ -1140,41 +1158,36 @@ namespace TrainworksReloaded.Base.Extensions
                 {
                     return null;
                 }
-                Comparator ret = 0;
+                Comparator? ret = 0;
                 foreach (var child in section.GetChildren())
                 {
-                    if (child.Value != null)
+                    var flag = DoParseComparator(child.Value);
+                    if (flag == null)
                     {
-                        ret |= (ParseComparator(section) ?? 0);
+                        return null;
                     }
+                    ret |= flag.Value;
                 }
                 return ret;
             }
-
-            val = val.ToLower();
-            var values = val.Split('|', StringSplitOptions.RemoveEmptyEntries)
-                           .Select(v => v.Trim())
-                           .ToList();
-
-            Comparator result = 0;
-            foreach (var value in values)
+            else
             {
-                Comparator? flag = value switch
-                {
-                    "less_than" => Comparator.LessThan,
-                    "greater_than" => Comparator.GreaterThan,
-                    "equal" => Comparator.Equal,
-                    _ => null
-                };
+                var values = val.Split('|', StringSplitOptions.RemoveEmptyEntries)
+                               .Select(v => v.Trim())
+                               .ToList();
 
-                if (flag == null)
+                Comparator result = 0;
+                foreach (var value in values)
                 {
-                    return null;
+                    Comparator? flag = DoParseComparator(value);
+                    if (flag == null)
+                    {
+                        return null;
+                    }
+                    result |= flag.Value;
                 }
-
-                result |= flag.Value;
+                return result;
             }
-            return result;
         }
     }
 }

--- a/TrainworksReloaded.Base/Relic/RelicEffectConditionDefinition.cs
+++ b/TrainworksReloaded.Base/Relic/RelicEffectConditionDefinition.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Configuration;
+using TrainworksReloaded.Core.Interfaces;
+
+namespace TrainworksReloaded.Base.Relic
+{
+    public class RelicEffectConditionDefinition(string key, RelicEffectCondition data, IConfiguration configuration)
+        : IDefinition<RelicEffectCondition>
+    {
+        public string Key { get; set; } = key;
+        public RelicEffectCondition Data { get; set; } = data;
+        public IConfiguration Configuration { get; set; } = configuration;
+        public string Id { get; set; } = "";
+        public bool IsModded => true;
+    }
+} 

--- a/TrainworksReloaded.Base/Relic/RelicEffectConditionFinalizer.cs
+++ b/TrainworksReloaded.Base/Relic/RelicEffectConditionFinalizer.cs
@@ -48,7 +48,7 @@ namespace TrainworksReloaded.Base.Relic
             {
                 var id = subtypeReference.ToId(key, TemplateConstants.Subtype);
                 subtypeRegister.TryLookupId(id, out var lookup, out var _);
-                AccessTools.Field(typeof(RelicEffectCondition), "paramSubtype").SetValue(data, lookup);
+                AccessTools.Field(typeof(RelicEffectCondition), "paramSubtype").SetValue(data, lookup?.Key);
             }
         }
     }

--- a/TrainworksReloaded.Base/Relic/RelicEffectConditionFinalizer.cs
+++ b/TrainworksReloaded.Base/Relic/RelicEffectConditionFinalizer.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using HarmonyLib;
+using TrainworksReloaded.Base.Extensions;
+using TrainworksReloaded.Core.Interfaces;
+using UnityEngine;
+using static TrainworksReloaded.Base.Extensions.ParseReferenceExtensions;
+
+namespace TrainworksReloaded.Base.Relic
+{
+    public class RelicEffectConditionFinalizer : IDataFinalizer
+    {
+        private readonly IModLogger<RelicEffectConditionFinalizer> logger;
+        private readonly ICache<IDefinition<RelicEffectCondition>> cache;
+        private readonly IRegister<SubtypeData> subtypeRegister;
+
+        public RelicEffectConditionFinalizer(
+            IModLogger<RelicEffectConditionFinalizer> logger,
+            ICache<IDefinition<RelicEffectCondition>> cache,
+            IRegister<SubtypeData> register
+        )
+        {
+            this.logger = logger;
+            this.cache = cache;
+            this.subtypeRegister = register;
+        }
+
+        public void FinalizeData()
+        {
+            foreach (var definition in cache.GetCacheItems())
+            {
+                FinalizeItem(definition);
+            }
+            cache.Clear();
+        }
+
+        private void FinalizeItem(IDefinition<RelicEffectCondition> definition)
+        {
+            var configuration = definition.Configuration;
+            var data = definition.Data;
+            var key = definition.Key;
+
+            logger.Log(LogLevel.Debug, $"Finalizing RelicEffectCondition {key} {definition.Id}...");
+            
+            var subtypeReference = configuration.GetSection("param_subtype").ParseReference();
+            if (subtypeReference != null)
+            {
+                var id = subtypeReference.ToId(key, TemplateConstants.Subtype);
+                subtypeRegister.TryLookupId(id, out var lookup, out var _);
+                AccessTools.Field(typeof(RelicEffectCondition), "paramSubtype").SetValue(data, lookup);
+            }
+        }
+    }
+} 

--- a/TrainworksReloaded.Base/Relic/RelicEffectConditionPipeline.cs
+++ b/TrainworksReloaded.Base/Relic/RelicEffectConditionPipeline.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using TrainworksReloaded.Base.Extensions;
+using TrainworksReloaded.Base.Localization;
+using TrainworksReloaded.Core.Extensions;
+using TrainworksReloaded.Core.Impl;
+using TrainworksReloaded.Core.Interfaces;
+using HarmonyLib;
+using UnityEngine;
+using System.Linq;
+
+namespace TrainworksReloaded.Base.Relic
+{
+    public class RelicEffectConditionPipeline : IDataPipeline<IRegister<RelicEffectCondition>, RelicEffectCondition>
+    {
+        private readonly PluginAtlas atlas;
+        private readonly IModLogger<RelicEffectConditionPipeline> logger;
+
+        public RelicEffectConditionPipeline(
+            PluginAtlas atlas,
+            IModLogger<RelicEffectConditionPipeline> logger
+        )
+        {
+            this.atlas = atlas;
+            this.logger = logger;
+        }
+
+        public List<IDefinition<RelicEffectCondition>> Run(IRegister<RelicEffectCondition> register)
+        {
+            var processList = new List<IDefinition<RelicEffectCondition>>();
+            foreach (var config in atlas.PluginDefinitions)
+            {
+                processList.AddRange(LoadRelicEffectConditions(register, config.Key, config.Value.Configuration));
+            }
+            return processList;
+        }
+
+        private List<RelicEffectConditionDefinition> LoadRelicEffectConditions(
+            IRegister<RelicEffectCondition> service,
+            string key,
+            IConfiguration pluginConfig
+        )
+        {
+            var processList = new List<RelicEffectConditionDefinition>();
+            foreach (var child in pluginConfig.GetSection("relic_effect_conditions").GetChildren())
+            {
+                var data = LoadRelicEffectCondition(service, key, child);
+                if (data != null)
+                {
+                    processList.Add(data);
+                }
+            }
+            return processList;
+        }
+
+        private RelicEffectConditionDefinition? LoadRelicEffectCondition(
+            IRegister<RelicEffectCondition> service,
+            string key,
+            IConfigurationSection configuration
+        )
+        {
+            var internalID = configuration.GetSection("id").ParseString();
+            if (string.IsNullOrEmpty(internalID))
+            {
+                logger.Log(LogLevel.Error, $"Relic effect condition configuration missing required 'id' field");
+                return null;
+            }
+
+            var name = key.GetId(TemplateConstants.RelicEffectCondition, internalID);
+            var data = new RelicEffectCondition();
+
+            var paramTrackedValue = CardStatistics.TrackedValueType.SubtypeInDeck;
+            AccessTools
+                .Field(typeof(RelicEffectCondition), "paramTrackedValue")
+                .SetValue(data, configuration.GetSection("param_tracked_value").ParseTrackedValueType() ?? paramTrackedValue);
+
+            var paramCardType = CardStatistics.CardTypeTarget.Any;
+            AccessTools
+                .Field(typeof(RelicEffectCondition), "paramCardType")
+                .SetValue(data, configuration.GetSection("param_card_type").ParseCardTypeTarget() ?? paramCardType);
+
+            var paramEntryDuration = CardStatistics.EntryDuration.ThisTurn;
+            AccessTools
+                .Field(typeof(RelicEffectCondition), "paramEntryDuration")
+                .SetValue(data, configuration.GetSection("param_entry_duration").ParseEntryDuration() ?? paramEntryDuration);
+
+            AccessTools
+                .Field(typeof(RelicEffectCondition), "paramTrackTriggerCount")
+                .SetValue(data, configuration.GetSection("param_track_trigger_count").ParseBool() ?? false);
+
+            var paramComparator = RelicEffectCondition.Comparator.Equal | RelicEffectCondition.Comparator.GreaterThan;
+            AccessTools
+                .Field(typeof(RelicEffectCondition), "paramComparator")
+                .SetValue(data, configuration.GetSection("param_comparator").ParseComparator() ?? paramComparator);
+
+            AccessTools
+                .Field(typeof(RelicEffectCondition), "paramInt")
+                .SetValue(data, configuration.GetSection("param_int").ParseInt() ?? 0);
+
+            AccessTools
+                .Field(typeof(RelicEffectCondition), "allowMultipleTriggersPerDuration")
+                .SetValue(data, configuration.GetSection("allow_multiple_triggers_per_duration").ParseBool() ?? true);
+
+
+            service.Register(name, data);
+            return new RelicEffectConditionDefinition(key, data, configuration){
+                Id = internalID
+            };
+        }
+    }
+}

--- a/TrainworksReloaded.Base/Relic/RelicEffectConditionRegister.cs
+++ b/TrainworksReloaded.Base/Relic/RelicEffectConditionRegister.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using TrainworksReloaded.Core.Enum;
+using TrainworksReloaded.Core.Interfaces;
+
+namespace TrainworksReloaded.Base.Relic
+{
+    public class RelicEffectConditionRegister : Dictionary<string, RelicEffectCondition>, IRegister<RelicEffectCondition>
+    {
+        private readonly IModLogger<RelicEffectConditionRegister> logger;
+
+        public RelicEffectConditionRegister(GameDataClient client, IModLogger<RelicEffectConditionRegister> logger)
+        {
+            this.logger = logger;
+        }
+
+        public List<string> GetAllIdentifiers(RegisterIdentifierType identifierType)
+        {
+            return identifierType switch
+            {
+                RegisterIdentifierType.ReadableID => [.. this.Keys],
+                RegisterIdentifierType.GUID => [.. this.Keys],
+                _ => [],
+            };
+        }
+
+        public void Register(string key, RelicEffectCondition item)
+        {
+            logger.Log(LogLevel.Info, $"Register RelicEffectCondition {key}... ");
+            Add(key, item);
+        }
+
+        public bool TryLookupIdentifier(string identifier, RegisterIdentifierType identifierType, [NotNullWhen(true)] out RelicEffectCondition? lookup, [NotNullWhen(true)] out bool? IsModded)
+        {
+            lookup = null;
+            IsModded = true;
+            switch (identifierType)
+            {
+                case RegisterIdentifierType.ReadableID:
+                    return this.TryGetValue(identifier, out lookup);
+                case RegisterIdentifierType.GUID:
+                    return this.TryGetValue(identifier, out lookup);
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/TrainworksReloaded.Base/TemplateConstants.cs
+++ b/TrainworksReloaded.Base/TemplateConstants.cs
@@ -32,5 +32,6 @@ namespace TrainworksReloaded.Base
         public const string Chatter = "Chatter";
         public const string Subtype = "Subtype";
         public const string AdditionalTooltip = "AdditionalTooltip";
+        public const string RelicEffectCondition = "RelicEffectCondition";
     }
 }

--- a/TrainworksReloaded.Plugin/RailheadPlugin.cs
+++ b/TrainworksReloaded.Plugin/RailheadPlugin.cs
@@ -139,6 +139,7 @@ namespace TrainworksReloaded.Plugin
                         typeof(CharacterChatterFinalizer),
                         typeof(RelicDataFinalizer),
                         typeof(RelicEffectDataFinalizer),
+                        typeof(RelicEffectConditionFinalizer),
                         typeof(GameObjectFinalizer),
                     ]
                 );
@@ -615,6 +616,20 @@ namespace TrainworksReloaded.Plugin
                 {
                     var pipeline = c.GetInstance<
                         IDataPipeline<IRegister<RelicEffectData>, RelicEffectData>
+                    >();
+                    pipeline.Run(x);
+                });
+
+                c.RegisterSingleton<IRegister<RelicEffectCondition>, RelicEffectConditionRegister>();
+                c.RegisterSingleton<RelicEffectConditionRegister, RelicEffectConditionRegister>();
+                c.Register<
+                    IDataPipeline<IRegister<RelicEffectCondition>, RelicEffectCondition>,
+                    RelicEffectConditionPipeline
+                >();
+                c.RegisterInitializer<IRegister<RelicEffectCondition>>(x =>
+                {
+                    var pipeline = c.GetInstance<
+                        IDataPipeline<IRegister<RelicEffectCondition>, RelicEffectCondition>
                     >();
                     pipeline.Run(x);
                 });

--- a/schemas/base.json
+++ b/schemas/base.json
@@ -50,6 +50,9 @@
     "map_nodes": {
       "$ref": "schemas/map_nodes.json#/properties/map_nodes"
     },
+    "relic_effect_conditions": {
+      "$ref": "schemas/relic_effect_conditions.json#/properties/relic_effect_conditions"
+    },
     "relic_effects": {
       "$ref": "schemas/relic_effects.json#/properties/relic_effects"
     },

--- a/schemas/schemas/relic_effect_conditions.json
+++ b/schemas/schemas/relic_effect_conditions.json
@@ -1,0 +1,57 @@
+{
+  "$id": "https://raw.githubusercontent.com/Monster-Train-2-Modding-Group/Trainworks-Reloaded/refs/heads/main/schemas/schemas/relic_effect_conditions.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "relic_effect_conditions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "allow_multiple_triggers_per_duration": {
+            "type": "boolean",
+            "description": "Allow multiple triggers per duration that is defined by the entry duration. This can be used to limit a relic from triggerring more than X times per turn or per battle."
+          },
+          "param_card_type": {
+            "$ref": "../definitions/card_type_target.json",
+            "description": "Card type target parameter for reading tracked value statistics."
+          },
+          "param_comparator": {
+            "$ref": "../definitions/comparator.json",
+            "description": "Operator for excluded status effects.",
+            "default": [ "equal", "greater_than" ]
+          },
+          "param_entry_duration": {
+            "$ref": "../definitions/entry_duration.json",
+            "description": "Duration of the tracked value statistic to fetch"
+          },
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Unique identifier for this relic effect condition."
+          },
+          "param_int": {
+            "type": "integer",
+            "description": "Integer parameter for the relic effect condition."
+          },
+          "param_subtype": {
+            "$ref": "../definitions/subtype.json",
+            "description": "Subtype parameter.",
+            "default": "SubtypesData_None"
+          },
+          "param_tracked_value": {
+            "$ref": "../definitions/tracked_value_type.json",
+            "description": "The tracked variable statistic to get for the relic effect condition.",
+            "default": "subtype_in_deck"
+          },
+          "param_track_trigger_count": {
+            "type": "boolean",
+            "description": "Determines if we should use the total trigger count as the tracked value instead of using a value from CardStatistics. Use this to limit triggers to X per turn or per battle."
+          }
+        }
+      },
+      "description": "Array of relic effect definitions"
+    }
+  },
+  "type": "object"
+}

--- a/schemas/schemas/relic_effects.json
+++ b/schemas/schemas/relic_effects.json
@@ -31,6 +31,13 @@
             },
             "description": "Array of card triggers"
           },
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "../definitions/reference.json"
+            },
+            "description": "Array of references to RelicEffectConditions."
+          },
           "param_card_type": {
             "$ref": "../definitions/card_type.json",
             "description": "Card type parameter",


### PR DESCRIPTION
## Summary
Relic Effect Conditions, and slight change to upgrade_masks.card_target_mode processing


## Test JSON
```
  "relic_effects": [
    {
      "id": "StewardsRampageDamageAll",
      "name": "RelicEffectDamageOnMonsterSummoned",
      "param_int": 50,
      "source_team": "heroes",
      "target_mode": "tower",
      "conditions": [ "@NumSummonedStewardsGreaterThan4" ]
    }
  ],
  "relic_effect_conditions": [
    {
      "id": "NumSummonedStewardsGreaterThan4",
      "param_tracked_value": "monster_subtype_played",
      "param_card_type": "monster",
      "param_subtype": "SubtypesData_TrainSteward",
      "param_entry_duration": "this_battle",
      "param_comparator": "equal",
      "param_int": 4,
      "allow_multiple_triggers_per_duration": false
    }
  ]
```

## Checklist
- [x] relic_effects.conditions
- [x] relic_effect_conditions
- [x] upgrade_masks.card_target_mode (unofficially) can be a string composed of a bit mask.
