### PR TITLE
Updated card style

### DIFF
--- a/TrainworksReloaded.Base/Extensions/ParseEnumExtensions.cs
+++ b/TrainworksReloaded.Base/Extensions/ParseEnumExtensions.cs
@@ -292,6 +292,14 @@ namespace TrainworksReloaded.Base.Extensions
                 "none" => ClassCardStyle.None,
                 "banished" => ClassCardStyle.Banished,
                 "pyreborne" => ClassCardStyle.Pyreborne,
+                "luna_coven" => ClassCardStyle.LunaCoven,
+                "underlegion" => ClassCardStyle.Underlegion,
+                "lazarus_league" => ClassCardStyle.LazarusLeague,
+                "hellhorned" => ClassCardStyle.Hellhorned,
+                "awoken" => ClassCardStyle.Awoken,
+                "stygian_guard" => ClassCardStyle.Stygian,
+                "umbra" => ClassCardStyle.Umbra,
+                "melting_remnant" => ClassCardStyle.Remnant,
                 _ => null,
             };
         }

--- a/schemas/definitions/card_style.json
+++ b/schemas/definitions/card_style.json
@@ -5,6 +5,14 @@
     "enum": [
         "none",
         "banished",
-        "pyreborne"
+        "pyreborne",
+        "luna_coven",
+        "underlegion",
+        "lazarus_league",
+        "hellhorned",
+        "awoken",
+        "stygian_guard",
+        "umbra",
+        "melting_remnant"
     ]
 }


### PR DESCRIPTION
## Summary
This PR added the list of missing faction from `ParseEnumExtensions.cs`

## Changes
Added:
- Luna Coven
- Underlegion
- Lazarus League
- Hellhorned
- Awoken
- Stygian Guard
- Umbra
- Melting Remnant

## Checklist
- [card_style.json]
